### PR TITLE
fix for old cookbook attribute

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -71,7 +71,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "aet" => {
         "karaf" => {
           "java_max_mem" => "3072M",
-          "debug" => true
+          "enable_debug" => true
         },
         "version" => "2.0.0"
       }


### PR DESCRIPTION
Atribute for Karaf debug should be `enable_debug`. See [aet-cookbook atributes](https://github.com/Cognifide/aet-cookbook#attributes) and [aet-cookbook source code](https://github.com/Cognifide/aet-cookbook/blob/master/attributes/karaf.rb#L36).