### PR TITLE
fix source report artifact error

### DIFF
--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/source/SourceCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/source/SourceCollector.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeoutException;
 public class SourceCollector implements CollectorJob {
 
   public static final String NAME = "source";
-
+  public static final String CONTENT_TYPE = "text/html";
   private static final String CHAR_ENCODING = "UTF-8";
 
   private final ArtifactsDAO artifactsDAO;
@@ -72,7 +72,7 @@ public class SourceCollector implements CollectorJob {
         throw new ProcessingException("Page source is empty!");
       }
       dataInputStream = IOUtils.toInputStream(pageSource, CHAR_ENCODING);
-      String resultId = artifactsDAO.saveArtifact(properties, dataInputStream);
+      String resultId = artifactsDAO.saveArtifact(properties, dataInputStream, CONTENT_TYPE);
       stepResult = CollectorStepResult.newCollectedResult(resultId);
 
     } catch (Exception e) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/source/SourceCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/source/SourceCollector.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeoutException;
 public class SourceCollector implements CollectorJob {
 
   public static final String NAME = "source";
-  public static final String CONTENT_TYPE = "text/html";
+  private static final String CONTENT_TYPE = "text/html";
   private static final String CHAR_ENCODING = "UTF-8";
 
   private final ArtifactsDAO artifactsDAO;

--- a/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
+++ b/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
@@ -88,9 +88,10 @@ define(['angularAMD', 'artifactsService'], function (angularAMD) {
         artifactsService.getArtifact(caseModel.comparator.stepResult.artifactId)
             .then(function (data) {
               caseModel.result = data;
-            }).catch(function (e) {
+            })
+            .catch(function (e) {
               console.log(e);
-        });
+            });
       }
     }
 
@@ -124,7 +125,6 @@ define(['angularAMD', 'artifactsService'], function (angularAMD) {
       caseModel.step = step;
 
       update();
-      
       getResultArtifact();
       initializeCollectorResultArtifact();
     }
@@ -166,15 +166,16 @@ define(['angularAMD', 'artifactsService'], function (angularAMD) {
       //FIXME this should be handled another way, currently because of a wrong content type of source artifact
       // there is error with parsing (says json instead html). There is no need to download source artifact,
       // it is not presented on the report.
-      var notSourceCollector = caseModel.step.type !== "source";
+      var notSourceCollector = caseModel.step.type !== 'source';
       if (collectorHasResult && notSourceCollector) {
         console.log('Getting: ', caseModel.step.stepResult.artifactId);
         artifactsService.getArtifact(caseModel.step.stepResult.artifactId)
             .then(function (data) {
               caseModel.collectorResult = data;
-            }).catch(function (e) {
+            })
+            .catch(function (e) {
               console.log(e);
-        });
+            });
       }
     }
 

--- a/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
+++ b/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
@@ -163,12 +163,17 @@ define(['angularAMD', 'artifactsService'], function (angularAMD) {
 
     function initializeCollectorResultArtifact() {
       var collectorHasResult = caseModel.step.stepResult && caseModel.step.stepResult.artifactId;
-      if (collectorHasResult) {
+      //FIXME this should be handled another way, currently because of a wrong content type of source artifact
+      // there is error with parsing (says json instead html). There is no need to download source artifact,
+      // it is not presented on the report.
+      var notSourceCollector = caseModel.step.type !== "source";
+      if (collectorHasResult && notSourceCollector) {
+        console.log('Getting: ', caseModel.step.stepResult.artifactId);
         artifactsService.getArtifact(caseModel.step.stepResult.artifactId)
             .then(function (data) {
               caseModel.collectorResult = data;
             }).catch(function (e) {
-          console.log(e);
+              console.log(e);
         });
       }
     }

--- a/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
+++ b/report/src/main/webapp/app/layout/main/url/caseFactory.service.js
@@ -162,20 +162,24 @@ define(['angularAMD', 'artifactsService'], function (angularAMD) {
     }
 
     function initializeCollectorResultArtifact() {
-      var collectorHasResult = caseModel.step.stepResult && caseModel.step.stepResult.artifactId;
-      //FIXME this should be handled another way, currently because of a wrong content type of source artifact
-      // there is error with parsing (says json instead html). There is no need to download source artifact,
-      // it is not presented on the report.
-      var notSourceCollector = caseModel.step.type !== 'source';
-      if (collectorHasResult && notSourceCollector) {
-        console.log('Getting: ', caseModel.step.stepResult.artifactId);
-        artifactsService.getArtifact(caseModel.step.stepResult.artifactId)
-            .then(function (data) {
-              caseModel.collectorResult = data;
-            })
-            .catch(function (e) {
-              console.log(e);
-            });
+      var collectorHasResult = caseModel.step.stepResult && caseModel.step.stepResult.artifactId,
+          sourceCollector = caseModel.step.type === 'source',
+          artifactId;
+
+      if (collectorHasResult) {
+        artifactId = caseModel.step.stepResult.artifactId;
+        if (sourceCollector) {
+          caseModel.collectorResult = artifactsService.getArtifactUrl(artifactId);
+        } else {
+          console.log('Getting: ', artifactId);
+          artifactsService.getArtifact(artifactId)
+              .then(function (data) {
+                caseModel.collectorResult = data;
+              })
+              .catch(function (e) {
+                console.log(e);
+              });
+        }
       }
     }
 

--- a/report/src/main/webapp/app/layout/main/url/reports/source.html
+++ b/report/src/main/webapp/app/layout/main/url/reports/source.html
@@ -37,7 +37,14 @@
   </div>
 </div>
 <div class="diff-report">
-  <span ng-if="case.status == 'PASSED' || case.status == 'REBASED'" class="test-no-issues">No issues found</span>
+
+  <div ng-if="case.status == 'PASSED' || case.status == 'REBASED'" class="test-no-issues">
+    <div>No issues found</div>
+    <div>
+      <a href="{{case.collectorResult}}" target="_blank">View collected source</a>
+    </div>
+  </div>
+
   <div ng-if="case.status == 'FAILED' || case.status == 'WARNING'">
     <div class="clearfix"></div>
     <div class="col-xs-6">

--- a/report/src/main/webapp/app/services/artifacts.service.js
+++ b/report/src/main/webapp/app/services/artifacts.service.js
@@ -50,7 +50,7 @@ define(['angularAMD', 'endpointConfiguration', 'requestParametersService'], func
         deferred.resolve(data.data);
         return deferred.promise;
       }).catch(function (exception) {
-        handleFailed('Failed to load artifact!', exception);
+        handleFailed('Failed to load artifact ' + artifactId, exception);
       });
     }
 


### PR DESCRIPTION
Fixed error at report on source comparison report:

```
/report/assets/libs/angular/angular.js:13550 SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at fromJson (/report/assets/libs/angular/angular.js:1321)
    at defaultHttpResponseTransform (/report/assets/libs/angular/angular.js:10393)
    at /report/assets/libs/angular/angular.js:10484
    at forEach (/report/assets/libs/angular/angular.js:322)
    at transformData (/report/assets/libs/angular/angular.js:10483)
    at transformResponse (/report/assets/libs/angular/angular.js:11278)
    at processQueue (/report/assets/libs/angular/angular.js:15961)
    at /report/assets/libs/angular/angular.js:15977
    at Scope.$eval (/report/assets/libs/angular/angular.js:17229)(anonymous function) @ /report/assets/libs/angular/angular.js:13550
artifacts.service.js:62 Failed to load artifact! Object SyntaxError: Unexpected token < in JSON at position 0(…)handleFailed @ artifacts.service.js:62
```

The reason is invalid content type of source artifact (which was set to `application/json` - fixed also).
It is also not necessary downloaded which was also fixed.
___

I hereby agree to the terms of the AET Contributor License Agreement.