### PR TITLE
Update for documentation and default proxy

### DIFF
--- a/client/client-core/src/main/java/com/cognifide/aet/model/TestRun.java
+++ b/client/client-core/src/main/java/com/cognifide/aet/model/TestRun.java
@@ -50,7 +50,7 @@ public class TestRun implements Serializable {
    * @param urls - list of urls.
    * @param name - unique name of test.
    * @param useProxy - says what kind of proxy should be used, backward compatibility: set 'true' to use
-   * embedded, set 'false' to use none.
+   * 'rest' proxy, set 'false' to use none.
    * @param zIndex - specifies order of tests. A test with greater value is always before test with lower zIndex.
    */
   public TestRun(List<CollectorStep> collectorSteps, Set<ComparatorStep> comparatorSteps,

--- a/documentation/src/main/wiki/ClientSidePerformanceCollector.md
+++ b/documentation/src/main/wiki/ClientSidePerformanceCollector.md
@@ -9,8 +9,8 @@ Client Side Performance Collector is responsible for collecting performance anal
 Module name: **client-side-performance**
 
 | ! Important information |
-|:----------------------- |
-| In order to use this collector **proxy** must be used. |
+| :---------------------- |
+| In order to use this collector *[[proxy|SuiteStructure#proxy]]* must be used. |
 
 ##### Parameters
 No parameters.

--- a/documentation/src/main/wiki/SuiteStructure.md
+++ b/documentation/src/main/wiki/SuiteStructure.md
@@ -17,27 +17,19 @@ Each **test** element contains:
 
 ##### Proxy
 
-Proxy is provided by two separated implementations: *embedded* and *rest*.
+Web proxy is required for some of the AET features:
 
-###### *embedded*
+* [Status codes|StatusCodesCollector]
+* [Header modifier|HeaderModifier]
+* [Client-side performance|ClientSidePerformanceCollector] (beta)
 
-*Embedded* proxy does not need standalone *[[Browsermob Server|WindowsSetup#browsermob-proxy-setup]]*, but does not support SSL. *Embedded* proxy is used as default when `useProxy` is setted to "true" (which is equivalent to setting `useProxy="embedded"`*)*.
-
-**Example usage**
-
-```xml
-<?xml version="1.0" encoding="UTF-8" ?>
-<suite name="test-suite" company="cognifide" project="project">
-    <test name="header-modify-test" useProxy="embedded">
-      ...
-    </test>
-    ...
-</suite>
-```
+AET proxy is currently provided by [BrowserMob Proxy](https://bmp.lightbody.net/) .
 
 ###### rest
 
-*Rest* proxy requires standalone *[[Browsermob Server|WindowsSetup#browsermob-proxy-setup]]*.
+*Rest* proxy requires standalone Browsermob server.
+See [[Linux and Windows Setup|LinuxAndWindowsSetup]] for more details.
+This proxy is used as default when `useProxy` is set to "true" (which is equivalent to setting `useProxy="rest"`*)*.
 
 **Example usage**
 

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
@@ -37,7 +37,7 @@ import java.util.Map;
 @Component(immediate = true, label = "AET Proxy Server Provider", description = "AET Proxy Server Provider")
 @Properties({@Property(name = Constants.SERVICE_VENDOR, value = "Cognifide Ltd")})
 public class ProxyServerProvider {
-  private static final String DEFAULT_PROXY_MANAGER = "embedded";
+  private static final String DEFAULT_PROXY_MANAGER = "rest";
 
   @Reference(referenceInterface = ProxyManager.class, policy = ReferencePolicy.DYNAMIC,
           cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, bind = "bindProxyManager",


### PR DESCRIPTION
As confirmed with @Skejven and @subiron the "embedded" proxy is no longer available in AET.