### PR TITLE
Removing not needed parameter

### DIFF
--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
@@ -50,14 +50,14 @@ public class WebDriverProvider {
   @Reference
   private ProxyServerProvider proxyServerProvider;
 
-  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String usedProxy)
+  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String proxyTypeConfig)
           throws WorkerException {
     WebDriverFactory webDriverFactory = collectorFactories.get(webDriverName);
     if (webDriverFactory == null) {
       throw new WorkerException("Undefined WebDriver " + webDriverName);
     }
     try {
-      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(usedProxy));
+      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(proxyTypeConfig));
     } catch (ProxyException e) {
       throw new WorkerException(String.format("Failed to connect: %s", e.getMessage()), e);
     }

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
@@ -50,14 +50,14 @@ public class WebDriverProvider {
   @Reference
   private ProxyServerProvider proxyServerProvider;
 
-  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String proxyTypeConfig)
+  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String useProxy)
           throws WorkerException {
     WebDriverFactory webDriverFactory = collectorFactories.get(webDriverName);
     if (webDriverFactory == null) {
       throw new WorkerException("Undefined WebDriver " + webDriverName);
     }
     try {
-      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(proxyTypeConfig));
+      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(useProxy));
     } catch (ProxyException e) {
       throw new WorkerException(String.format("Failed to connect: %s", e.getMessage()), e);
     }

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
@@ -50,14 +50,14 @@ public class WebDriverProvider {
   @Reference
   private ProxyServerProvider proxyServerProvider;
 
-  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String useProxy)
+  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String usedProxy)
           throws WorkerException {
     WebDriverFactory webDriverFactory = collectorFactories.get(webDriverName);
     if (webDriverFactory == null) {
       throw new WorkerException("Undefined WebDriver " + webDriverName);
     }
     try {
-      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(useProxy));
+      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(usedProxy));
     } catch (ProxyException e) {
       throw new WorkerException(String.format("Failed to connect: %s", e.getMessage()), e);
     }

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
@@ -50,14 +50,14 @@ public class WebDriverProvider {
   @Reference
   private ProxyServerProvider proxyServerProvider;
 
-  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String useProxy, int port)
+  public WebCommunicationWrapper createWebDriverWithProxy(String webDriverName, String useProxy)
           throws WorkerException {
     WebDriverFactory webDriverFactory = collectorFactories.get(webDriverName);
     if (webDriverFactory == null) {
       throw new WorkerException("Undefined WebDriver " + webDriverName);
     }
     try {
-      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(useProxy, port));
+      return webDriverFactory.createWebDriver(proxyServerProvider.createProxy(useProxy));
     } catch (ProxyException e) {
       throw new WorkerException(String.format("Failed to connect: %s", e.getMessage()), e);
     }

--- a/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
@@ -104,9 +104,9 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
       int collected = 0;
       try {
         //FIXME - proxy is now set per url
-        final String proxyTypeConfig = collectorJobData.getUrls().get(0).getProxy();
-        if (proxyShouldBeUsed(proxyTypeConfig)) {
-          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, proxyTypeConfig);
+        final String usedProxy = collectorJobData.getUrls().get(0).getProxy();
+        if (isProxyUsed(usedProxy)) {
+          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, usedProxy);
         } else {
           webCommunicationWrapper = this.webDriverProvider.createWebDriver(webDriverName);
         }
@@ -160,8 +160,8 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
     return result;
   }
 
-  private boolean proxyShouldBeUsed(String proxyTypeConfig) {
-    return StringUtils.isNotBlank(proxyTypeConfig) && !("false").equals(proxyTypeConfig);
+  private boolean isProxyUsed(String useProxy) {
+    return StringUtils.isNotBlank(useProxy) && !("false").equals(useProxy);
   }
 
   private void quitWebDriver(WebCommunicationWrapper webCommunicationWrapper) {

--- a/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
@@ -31,7 +31,6 @@ import com.cognifide.aet.worker.drivers.WebDriverProvider;
 import com.cognifide.aet.worker.exceptions.WorkerException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
@@ -105,9 +104,9 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
       int collected = 0;
       try {
         //FIXME - proxy is now set per url
-        final String usedProxy = collectorJobData.getUrls().get(0).getProxy();
-        if (isProxyUsed(usedProxy)) {
-          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, usedProxy);
+        final String proxyTypeConfig = collectorJobData.getUrls().get(0).getProxy();
+        if (proxyShouldBeUsed(proxyTypeConfig)) {
+          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, proxyTypeConfig);
         } else {
           webCommunicationWrapper = this.webDriverProvider.createWebDriver(webDriverName);
         }
@@ -161,8 +160,8 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
     return result;
   }
 
-  private boolean isProxyUsed(String useProxy) {
-    return StringUtils.isNotBlank(useProxy) && !("false").equals(useProxy);
+  private boolean proxyShouldBeUsed(String proxyTypeConfig) {
+    return StringUtils.isNotBlank(proxyTypeConfig) && !("false").equals(proxyTypeConfig);
   }
 
   private void quitWebDriver(WebCommunicationWrapper webCommunicationWrapper) {

--- a/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/listeners/CollectorMessageListenerImpl.java
@@ -55,10 +55,6 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
 
   private static final String WEB_DRIVER_NAME = "webDriverName";
 
-  private static final String PORT_NAME = "portName";
-
-  private static final int DEFAULT_PORT = 4444;
-
   @Property(name = LISTENER_NAME, label = "Collector name", description = "Name of collector. Used in logs only", value = "Collector")
   private String name;
 
@@ -70,9 +66,6 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
 
   @Property(name = WEB_DRIVER_NAME, label = "Web Driver name", value = "ff")
   private String webDriverName;
-
-  @Property(name = PORT_NAME, label = "Embedded Proxy Server Port", value = "4501")
-  private int port;
 
   @Reference
   private JmsConnection jmsConnection;
@@ -87,7 +80,6 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
   void activate(Map<String, String> properties) {
     super.doActivate(properties);
     webDriverName = properties.get(WEB_DRIVER_NAME);
-    port = NumberUtils.toInt(properties.get(PORT_NAME), DEFAULT_PORT);
   }
 
   @Deactivate
@@ -115,7 +107,7 @@ public class CollectorMessageListenerImpl extends AbstractTaskMessageListener {
         //FIXME - proxy is now set per url
         final String usedProxy = collectorJobData.getUrls().get(0).getProxy();
         if (isProxyUsed(usedProxy)) {
-          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, usedProxy, port);
+          webCommunicationWrapper = this.webDriverProvider.createWebDriverWithProxy(webDriverName, usedProxy);
         } else {
           webCommunicationWrapper = this.webDriverProvider.createWebDriver(webDriverName);
         }

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-A.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-A.cfg
@@ -20,5 +20,4 @@ name=Collector1
 consumerQueueName=AET.collectorJobs
 producerQueueName=AET.collectorResults
 webDriverName=ff
-portName=4501
-pf= 1
+pf=1

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-B.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-B.cfg
@@ -20,5 +20,4 @@ name=Collector2
 consumerQueueName=AET.collectorJobs
 producerQueueName=AET.collectorResults
 webDriverName=ff
-portName=4502
 pf=1

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-C.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-C.cfg
@@ -20,5 +20,4 @@ name=Collector3
 consumerQueueName=AET.collectorJobs
 producerQueueName=AET.collectorResults
 webDriverName=ff
-portName=4503
 pf=1

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-D.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-D.cfg
@@ -20,5 +20,4 @@ name=Collector4
 consumerQueueName=AET.collectorJobs
 producerQueueName=AET.collectorResults
 webDriverName=ff
-portName=4504
 pf=1

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-E.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.listeners.CollectorMessageListenerImpl-E.cfg
@@ -20,5 +20,4 @@ name=Collector5
 consumerQueueName=AET.collectorJobs
 producerQueueName=AET.collectorResults
 webDriverName=ff
-portName=4505
 pf=1

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyManager.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyManager.java
@@ -24,6 +24,6 @@ public interface ProxyManager {
 
   String getName();
 
-  ProxyServerWrapper createProxy(int port) throws ProxyException;
+  ProxyServerWrapper createProxy() throws ProxyException;
 
 }

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
@@ -44,7 +44,7 @@ public class ProxyServerProvider {
           unbind = "unbindProxyManager")
   private final Map<String, ProxyManager> collectorManagers = Maps.newConcurrentMap();
 
-  public ProxyServerWrapper createProxy(String useProxy, int port) throws ProxyException {
+  public ProxyServerWrapper createProxy(String useProxy) throws ProxyException {
     String proxyType = useProxy;
     if ("true".equals(useProxy)) {
       proxyType = DEFAULT_PROXY_MANAGER;
@@ -54,9 +54,10 @@ public class ProxyServerProvider {
       throw new ProxyException("Undefined ProxyManager with proxyType: " + proxyType);
     }
     try {
-      return proxyManager.createProxy(port);
+      return proxyManager.createProxy();
     } catch (ProxyException e) {
-      throw new ProxyException("Unable to create ProxyServer on port " + port + " by ProxyManager", e);
+      String managerClass = proxyManager.getClass().getCanonicalName();
+      throw new ProxyException("Unable to create ProxyServer with ProxyManager: " + managerClass, e);
     }
   }
 

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
@@ -44,12 +44,10 @@ public class ProxyServerProvider {
           unbind = "unbindProxyManager")
   private final Map<String, ProxyManager> collectorManagers = Maps.newConcurrentMap();
 
-  public ProxyServerWrapper createProxy(String proxyTypeConfig) throws ProxyException {
-    String proxyType;
-    if ("true".equals(proxyTypeConfig)) {
+  public ProxyServerWrapper createProxy(String useProxy) throws ProxyException {
+    String proxyType = useProxy;
+    if ("true".equals(useProxy)) {
       proxyType = DEFAULT_PROXY_MANAGER;
-    } else {
-      proxyType = proxyTypeConfig;
     }
     ProxyManager proxyManager = collectorManagers.get(proxyType);
     if (proxyManager == null) {

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
@@ -44,9 +44,9 @@ public class ProxyServerProvider {
           unbind = "unbindProxyManager")
   private final Map<String, ProxyManager> collectorManagers = Maps.newConcurrentMap();
 
-  public ProxyServerWrapper createProxy(String useProxy) throws ProxyException {
-    String proxyType = useProxy;
-    if ("true".equals(useProxy)) {
+  public ProxyServerWrapper createProxy(String usedProxy) throws ProxyException {
+    String proxyType = usedProxy;
+    if ("true".equals(usedProxy)) {
       proxyType = DEFAULT_PROXY_MANAGER;
     }
     ProxyManager proxyManager = collectorManagers.get(proxyType);

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/ProxyServerProvider.java
@@ -44,10 +44,12 @@ public class ProxyServerProvider {
           unbind = "unbindProxyManager")
   private final Map<String, ProxyManager> collectorManagers = Maps.newConcurrentMap();
 
-  public ProxyServerWrapper createProxy(String usedProxy) throws ProxyException {
-    String proxyType = usedProxy;
-    if ("true".equals(usedProxy)) {
+  public ProxyServerWrapper createProxy(String proxyTypeConfig) throws ProxyException {
+    String proxyType;
+    if ("true".equals(proxyTypeConfig)) {
       proxyType = DEFAULT_PROXY_MANAGER;
+    } else {
+      proxyType = proxyTypeConfig;
     }
     ProxyManager proxyManager = collectorManagers.get(proxyType);
     if (proxyManager == null) {

--- a/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/RestProxyManager.java
+++ b/osgi-dependencies/proxy/src/main/java/com/cognifide/aet/proxy/RestProxyManager.java
@@ -101,10 +101,6 @@ public class RestProxyManager implements ProxyManager {
   }
 
   @Override
-  public RestProxyServer createProxy(int port) throws ProxyException {
-    return createProxy();
-  }
-
   public RestProxyServer createProxy() throws ProxyException {
     RestProxyServer proxy;
     if (manager == null) {


### PR DESCRIPTION
As there is no embedded proxy we don't need a port configuration for IT.
REST proxy has its own configuration (with a port number).