### PR TITLE
Move appending endpoint domain to urls to client

### DIFF
--- a/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
+++ b/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
@@ -92,7 +92,8 @@ public class TestSuiteRunner {
               "********************************************************************************");
       while (runnerTerminator.isActive()) {
         Thread.sleep(STATUS_CHECK_INTERVAL_MILLIS);
-        SuiteStatusResult suiteStatus = getSuiteStatus(suiteExecutionResult.getStatusUrl());
+        String statusFullUrl = endpointDomain + suiteExecutionResult.getStatusUrl();
+        SuiteStatusResult suiteStatus = getSuiteStatus(statusFullUrl);
         processStatus(runnerTerminator, suiteExecutionResult.getHtmlReportUrl(), suiteStatus);
       }
       if (xUnit) {
@@ -134,7 +135,8 @@ public class TestSuiteRunner {
 
   private void downloadXUnitTest(String xUnitUrl) {
     try {
-      new ReportWriter().write(buildDirectory, xUnitUrl, "xunit-report.xml");
+      String xUnitFullUrl = endpointDomain + xUnitUrl;
+      new ReportWriter().write(buildDirectory, xUnitFullUrl, "xunit-report.xml");
     } catch (IOException e) {
       Logger.error(this, "Failed to obtain xUnit report from: %s", xUnitUrl, e);
     }

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
@@ -125,11 +125,9 @@ public class SuiteExecutor {
    *
    * @param suiteString - content of the test suite XML file
    * @param domain - overrides domain defined in the suite file
-   * @param endpointDomain - domain under which AET system is available, used to create links to
-   *                       xUnit report and status check
    * @return status of the suite execution
    */
-  public SuiteExecutionResult execute(String suiteString, String domain, String endpointDomain) {
+  public SuiteExecutionResult execute(String suiteString, String domain) {
     SuiteRunner suiteRunner = null;
     SuiteExecutionResult result;
 
@@ -147,10 +145,10 @@ public class SuiteExecutor {
           suiteRunner = createSuiteRunner(suite);
           suiteRunner.runSuite();
 
-          String statusUrl = getStatusUrl(endpointDomain, suite);
+          String statusUrl = getStatusUrl(suite);
           String htmlReportUrl = getReportUrl(HTML_REPORT_URL_FORMAT,
               reportConfigurationManager.getReportDomain(), suite);
-          String xunitReportUrl = getReportUrl(XUNIT_REPORT_URL_FORMAT, endpointDomain, suite);
+          String xunitReportUrl = getReportUrl(XUNIT_REPORT_URL_FORMAT, StringUtils.EMPTY, suite);
           result = SuiteExecutionResult.createSuccessResult(suite.getCorrelationId(), statusUrl,
               htmlReportUrl, xunitReportUrl);
         } else {
@@ -216,8 +214,8 @@ public class SuiteExecutor {
     return String.format(format, domain, suite.getCompany(), suite.getProject(), suite.getCorrelationId());
   }
 
-  private String getStatusUrl(String domain, Suite suite) {
-    return domain + SuiteStatusServlet.SERVLET_PATH + "/" + suite.getCorrelationId();
+  private String getStatusUrl(Suite suite) {
+    return SuiteStatusServlet.SERVLET_PATH + "/" + suite.getCorrelationId();
   }
 
   private static class RunnerCacheRemovalListener implements RemovalListener<String, SuiteRunner> {

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
@@ -82,10 +82,9 @@ public class SuiteServlet extends HttpServlet {
       Map<String, String> requestData = getRequestData(request);
       String suite = requestData.get(SUITE_PARAM);
       String domain = requestData.get(DOMAIN_PARAM);
-      String endpointDomain = StringUtils.substringBefore(request.getRequestURL().toString(), SERVLET_PATH);
 
       if (StringUtils.isNotBlank(suite)) {
-        SuiteExecutionResult suiteExecutionResult = suiteExecutor.execute(suite, domain, endpointDomain);
+        SuiteExecutionResult suiteExecutionResult = suiteExecutor.execute(suite, domain);
         Gson gson = new Gson();
         String responseBody = gson.toJson(suiteExecutionResult);
 


### PR DESCRIPTION
Suite executor returns relative URLs to status check and xUnit report and client application appends endpoint domain to them. This prevents issues when AET domain starts with `https`.