### PR TITLE
#126 - fix for jcabi log parameters

### DIFF
--- a/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
+++ b/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
@@ -143,8 +143,8 @@ public class TestSuiteRunner {
     try {
       String xUnitFullUrl = endpointDomain + xUnitUrl;
       new ReportWriter().write(buildDirectory, xUnitFullUrl, "xunit-report.xml");
-    } catch (IOException e) {
-      Logger.error(this, "Failed to obtain xUnit report from: %s", xUnitUrl, e);
+    } catch (IOException ioe) {
+      Logger.error(this, "Failed to obtain xUnit report from: %s. Error: %s", xUnitUrl, ioe.getMessage());
     }
   }
 


### PR DESCRIPTION
[jcabi Logger](http://www.jcabi.com/jcabi-log/apidocs/index.html?com/jcabi/log/Logger.html) doesn't support throwable as argument.