### PR TITLE
removing migration appender (migration logger was removed earilier)

### DIFF
--- a/osgi-dependencies/configs/src/main/resources/org.ops4j.pax.logging.cfg
+++ b/osgi-dependencies/configs/src/main/resources/org.ops4j.pax.logging.cfg
@@ -167,17 +167,3 @@ log4j2.appender.worker.policies.size.type = SizeBasedTriggeringPolicy
 log4j2.appender.worker.policies.size.size = 8MB
 log4j2.appender.worker.strategy.type = DefaultRolloverStrategy
 log4j2.appender.worker.strategy.max = 5
-
-# migration tool file appender
-log4j2.appender.migration.type = RollingRandomAccessFile
-log4j2.appender.migration.name = Migration
-log4j2.appender.migration.layout.type = PatternLayout
-log4j2.appender.migration.layout.pattern = %d{ISO8601} | %-5.5p | %-24.24X{bundle.name} | %-32.32c{1} %4L | %m%n
-log4j2.appender.migration.fileName = ${karaf.data}/log/migration.log
-log4j2.appender.migration.filePattern = ${karaf.data}/log/migration.log.%i
-log4j2.appender.migration.append = true
-log4j2.appender.migration.policies.type = Policies
-log4j2.appender.migration.policies.size.type = SizeBasedTriggeringPolicy
-log4j2.appender.migration.policies.size.size = 8MB
-log4j2.appender.migration.strategy.type = DefaultRolloverStrategy
-log4j2.appender.migration.strategy.max = 5


### PR DESCRIPTION
## Description
Some time ago we have removed migration logger as this was used during the migration to AET version 2.0.0. However we forget about removing also an appender.

## Motivation and Context
We don't want to have this appender. We don't want to generate empty *migration.log* file that no logger will ever write to.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.