### PR TITLE
Feature/Add possibility to scroll side panel to currently opened test/url

### DIFF
--- a/report/src/main/webapp/app/layout/toolbar/toolbarBottom.controller.js
+++ b/report/src/main/webapp/app/layout/toolbar/toolbarBottom.controller.js
@@ -34,11 +34,20 @@ define([], function () {
     vm.showAcceptButton = patternsMayBeUpdated;
     vm.showRevertButton = patternsMarkedForUpdateMayBeReverted;
     vm.displayCommentModal = displayCommentModal;
+    vm.scrollSidepanel = scrollSidepanel;
 
     $rootScope.$on('metadata:changed', updateToolbar);
+    $scope.$watch('viewMode', function() {
+        setTimeout(function() {
+          $('[data-toggle="popover"]').not('.pre-initialized-popover').popover({
+                placement: 'bottom'
+          });
+        }, 0);
+    });
+
     $('[data-toggle="popover"]').popover({
       placement: 'bottom'
-    });
+    }).addClass('pre-initialized-popover');
 
     updateToolbar();
 
@@ -110,6 +119,20 @@ define([], function () {
       });
     }
 
+    function scrollSidepanel(findParentGroup) {
+      var element = $('a.test-name.is-active, a.test-url.is-active');
+      var reportGroup;
+
+      if (findParentGroup) {
+          reportGroup = element.closest('.aside-report.is-visible');
+          element = reportGroup.find('.test-name');
+          element.click();
+          reportGroup.addClass('is-expanded');
+      }
+
+      element[0].scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
+    }
+
     /***************************************
      ***********  SUITE VIEW PART  *********
      ***************************************/
@@ -141,8 +164,11 @@ define([], function () {
      ***********  URL VIEW PART  *********
      ***************************************/
     function setupUrlToolbarModel() {
+      var testName = $stateParams.test;
+
       vm.model = metadataAccessService.getUrl($stateParams.test,
           $stateParams.url);
+      vm.model.testGroupName = metadataAccessService.getTest(testName).name;
       vm.updatePatterns = function () {
         patternsService.updateUrl($stateParams.test, $stateParams.url, true);
       };

--- a/report/src/main/webapp/app/layout/toolbar/toolbarBottom.view.html
+++ b/report/src/main/webapp/app/layout/toolbar/toolbarBottom.view.html
@@ -20,15 +20,31 @@
 <div class="toolbar-bottom">
   <div class="toolbar-link">
     <h4 class="toolbar-link-header ellipsis">
-      <span class="preformatted">{{toolbarBottom.viewMode}}:</span>
-      <span ng-if="toolbarBottom.viewMode != 'url'">{{toolbarBottom.model.name}}</span>
-      <a ng-if="toolbarBottom.viewMode == 'url'"
-         href="{{toolbarBottom.model.domain + toolbarBottom.model.url}}" target="_blank"
-         data-toggle="popover"
-         data-content="Click to open: {{toolbarBottom.model.domain + toolbarBottom.model.url}}"
-         data-trigger="hover"
-         data-container="body">{{toolbarBottom.model.name}}</a>
+        <i class="glyphicon glyphicon-screenshot"
+           data-toggle="popover"
+           data-content="Localize the currently opened url on side panel"
+           data-trigger="hover"
+           data-container="body"
+           data-ng-click="toolbarBottom.scrollSidepanel(false)"></i>
+        <span class="preformatted">{{toolbarBottom.viewMode}}:</span>
+        <span ng-if="toolbarBottom.viewMode != 'url'">{{toolbarBottom.model.name}}</span>
+        <a ng-if="toolbarBottom.viewMode == 'url'"
+            href="{{toolbarBottom.model.domain + toolbarBottom.model.url}}" target="_blank"
+            data-toggle="popover"
+            data-content="Click to open: {{toolbarBottom.model.domain + toolbarBottom.model.url}}"
+            data-trigger="hover"
+            data-container="body">{{toolbarBottom.model.name}}</a>
     </h4>
+    <h5 ng-if="toolbarBottom.viewMode == 'url'">
+      <i class="glyphicon glyphicon-screenshot"
+         data-toggle="popover"
+         data-content="Localize the test group of the currently opened url on side panel"
+         data-trigger="hover"
+         data-container="body"
+         data-ng-click="toolbarBottom.scrollSidepanel(true)"></i>
+        </i>
+    <span class="preformatted">test:</span><span>{{toolbarBottom.model.testGroupName}}</span>
+    </h5>
   </div>
   <div class="toolbar-blocks">
     <div class="toolbar-btns is-absolute">

--- a/report/src/main/webapp/assets/sass/_toolbar.scss
+++ b/report/src/main/webapp/assets/sass/_toolbar.scss
@@ -99,18 +99,47 @@
     padding: 0 20px;
     background: $white;
 
-    h4 {
-      font-size: 24px;
+    h4, h5 {
       font-weight: normal;
       color: $gray_darker;
       padding-right: 20px;
-      line-height: 54px;
+
+      .glyphicon-screenshot {
+        position: relative;
+        cursor: pointer;
+      }
+
       a {
         color: $gray_darker;
 
         &:hover {
           color: darken($gray_darker, 10%);
         }
+      }
+    }
+
+    h4 {
+      font-size: 24px;
+      line-height: 54px;
+
+      .glyphicon-screenshot {
+        top: 4px;
+      }
+
+      &:not(:last-child) {
+        margin-bottom: 0;
+      }
+    }
+
+    h5 {
+      margin-top: 0;
+      margin-bottom: 26px;
+      padding-left: 4px;
+      font-size: 16px;
+      line-height: 18px;
+
+      .glyphicon-screenshot {
+        top: 3px;
       }
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a specific button that will allow to scroll the sidepanel content to the opened report - like the "Scroll from Source" button in IntelliJ. 
Add also an on-hover tooltip for it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now it is hard to find an opened report in sidepanel, especially when there are many of them and we've begun to scroll it.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/35067043/35976690-36a021d0-0ce1-11e8-9fb3-e7d18347c9ff.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.