### PR TITLE
fix for bento centos box location

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -33,6 +33,7 @@ Vagrant.require_version '>= 1.9.0'
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = 'aet-vagrant'
   config.vm.box = 'bento/centos-6.8'
+  config.vm.box_url = 'https://app.vagrantup.com/bento/boxes/centos-6.8'
   config.vm.box_check_update = true
 
   config.vm.network :private_network, ip: '192.168.123.100'


### PR DESCRIPTION
Fix for vagrant box location

## Motivation and Context
The default box location for bento centos is not valid anymore.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.