### PR TITLE
Switch off the default require.js timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-239](https://github.com/Cognifide/aet/pull/239) Switch off default require.js timeouts.
 - [PR-233](https://github.com/Cognifide/aet/pull/233) Font Awesome introduced to AET
 - [PR-228](https://github.com/Cognifide/aet/pull/228) Remove 'jump to' button from whole suite view.
 - [PR-230](https://github.com/Cognifide/aet/pull/230) Bug Fixed: Side panel items not accessible when 'Save/Discard Changes' buttons are visible.

--- a/report/src/main/webapp/app/app.config.js
+++ b/report/src/main/webapp/app/app.config.js
@@ -89,5 +89,6 @@ require.config({
     'angular-ui-router': ['angular'],
     'angularAMD': ['angular']
   },
-  deps: ['app.module']
+  deps: ['app.module'],
+  waitSeconds: 0
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change is switching off the default require.js timeout, to prevent report app from not loading while on slow network.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, in most cases, the report app is not loading on slow networks due to timeout caused by require.js (Uncaught Error: Load timeout for modules: angularAMD,lodash,angular-bootstrap,angular-ui-router,jquery,bootstrap,scroller,angular). This change is switching off the default timeout, to prevent it from happening.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.