### PR TITLE
update for focus of current item in sidepanel

### DIFF
--- a/report/src/main/webapp/app/layout/sidepanel/sidepanel.controller.js
+++ b/report/src/main/webapp/app/layout/sidepanel/sidepanel.controller.js
@@ -29,16 +29,22 @@ define([], function () {
 
     $rootScope.$on('metadata:changed', updateNavigationTree);
     $rootScope.$on('filter:applied', updateTestsStats);
-    $scope.$watch('sidepanel.tests', function() {
+    var expandSidepanel = function() {
+      console.log("expanding sidepanel: " + new Date());
       $timeout(function() {
-          var url = $location.url();
-          var hrefSelector = 'a[href="#' + url + '"';
-          var $element = $(hrefSelector);
+        var url = $location.url();
+        var hrefSelector = 'a[href="#' + url + '"';
+        var $element = $(hrefSelector);
 
-          $element.closest('.aside-report.is-visible').addClass('is-expanded');
-          $element[0].scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
+        $element.closest('.aside-report.is-visible').addClass('is-expanded');
+        $element[0].scrollIntoView({behavior: 'smooth', block: 'center', inline: 'nearest'});
       });
-    });
+    };
+
+    // when page is opened with specific URL for the first time:
+    $scope.$watch('sidepanel.tests', expandSidepanel);
+    // when new URL is pasted while viewing report:
+    $scope.$on('$locationChangeSuccess', expandSidepanel);
 
     $('[data-toggle="popover"]').popover({
       placement: 'bottom'


### PR DESCRIPTION
Update for case when URL is pasted on current report.

## Description
It looks like scroll to current item on sidepanel was working only on first load of the page with specific URL. for the next load of different test of the same suite the focus didn't work.

## Motivation and Context
We want sidepanel to always follow the current element when the URL is copy-pasted into browser address bar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.