### PR TITLE
Recipes reordered to be in same order as in cookbook

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -96,22 +96,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }
     chef.run_list = [
       "recipe[aet::_develop]",
-# commented for now as we want to release a version without Selenium Grid
-#      "recipe[aet::seleniumgrid_hub]",
-#      "recipe[aet::seleniumgrid_node_ff]",
-      "recipe[aet::karaf]",
-      "recipe[aet::deploy_aet_for_karaf]",
-      "recipe[aet::postdeploy_restart]",
-      "recipe[aet::apache]",
-      "recipe[aet::deploy_reports]",
-      "recipe[aet::tomcat]",
-      "recipe[aet::deploy_sample_site]",
       "recipe[aet::display]",
+      "recipe[aet::apache]",
       "recipe[aet::mongo]",
       "recipe[aet::activemq]",
       "recipe[aet::browsermob]",
       "recipe[aet::firefox]",
       "recipe[aet::xvfb]",
+      "recipe[aet::tomcat]",
+# commented for now as we want to release a version without Selenium Grid
+#      "recipe[aet::seleniumgrid_hub]",
+#      "recipe[aet::seleniumgrid_node_ff]",
+      "recipe[aet::karaf]",
+      "recipe[aet::deploy_aet_for_karaf]",
+      "recipe[aet::deploy_reports]",
+      "recipe[aet::deploy_sample_site]",
+      "recipe[aet::postdeploy_restart]",
       "recipe[aet::reboot]"
     ]
   end


### PR DESCRIPTION
## Description
Recipes order should probably be the sam as in [aet-cookbook default recipe](https://github.com/Cognifide/aet-cookbook/blob/master/recipes/default.rb).

## Motivation and Context
Let's be consistent about recipes order.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.