### PR TITLE
removing execution that is no longer needed

### DIFF
--- a/osgi-dependencies/pom.xml
+++ b/osgi-dependencies/pom.xml
@@ -40,35 +40,6 @@
     <module>w3chtml5validator</module>
   </modules>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.basedir}</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/templates</directory>
-                  <filtering>true</filtering>
-                  <includes>
-                    <include>aet-features.xml</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>upload</id>


### PR DESCRIPTION
removing execution that is no longer needed after https://github.com/Cognifide/aet/pull/261

## Description
We are no longer generating *aet-features.xml* file from template so we should remove the eecution of MAven resources plugin that was used to generate this file from template (with replaced placeholders).

## Motivation and Context
Fix for missing change of another pull request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.