### PR TITLE
Guice removed completely

### DIFF
--- a/core/jobs/pom.xml
+++ b/core/jobs/pom.xml
@@ -127,10 +127,6 @@
       <artifactId>xmlunit</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guiceberry</groupId>
-      <artifactId>guiceberry</artifactId>
-    </dependency>
-    <dependency>
       <groupId>uk.co.jemos.podam</groupId>
       <artifactId>podam</artifactId>
     </dependency>

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/statuscodesfilter/ExcludeStatusCodesFilterTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/statuscodesfilter/ExcludeStatusCodesFilterTest.java
@@ -15,10 +15,10 @@
  */
 package com.cognifide.aet.job.common.datafilters.statuscodesfilter;
 
-import static com.google.common.testing.GuavaAsserts.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.cognifide.aet.job.api.exceptions.ParametersException;

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/statuscodesfilter/IncludeStatusCodesFilterTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/statuscodesfilter/IncludeStatusCodesFilterTest.java
@@ -15,10 +15,10 @@
  */
 package com.cognifide.aet.job.common.datafilters.statuscodesfilter;
 
-import static com.google.common.testing.GuavaAsserts.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.cognifide.aet.job.api.exceptions.ParametersException;

--- a/core/worker/pom.xml
+++ b/core/worker/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-osgi</artifactId>
     </dependency>

--- a/osgi-dependencies/aet-features.xml
+++ b/osgi-dependencies/aet-features.xml
@@ -60,19 +60,6 @@
         <bundle>mvn:org.apache.felix/org.apache.felix.http.servlet-api/1.1.2</bundle>
     </feature>
 
-    <feature name="aet-guice" version="0.6.0" description="Bundles for Guice" install="auto">
-
-        <bundle>wrap:mvn:javax.inject/javax.inject/1</bundle>
-
-        <!-- required by guice-servlet -->
-        <bundle>mvn:org.apache.felix/org.apache.felix.http.servlet-api/1.1.2</bundle>
-
-        <bundle>mvn:com.google.inject/guice/3.0</bundle>
-        <bundle>mvn:com.google.inject.extensions/guice-assistedinject/3.0</bundle>
-        <bundle>mvn:com.google.inject.extensions/guice-servlet/3.0</bundle>
-    </feature>
-
-
     <feature name="aet-jackson" version="0.6.0" description="Bundles for Jackson" install="auto">
 
         <bundle>mvn:javax.ws.rs/javax.ws.rs-api/2.1</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -167,12 +167,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.inject</groupId>
-        <artifactId>guice</artifactId>
-        <version>3.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-osgi</artifactId>
         <version>5.13.1</version>
@@ -351,12 +345,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-assistedinject</artifactId>
-        <version>3.0</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.simpleframework</groupId>
         <artifactId>simple-xml</artifactId>
         <version>2.7.1</version>
@@ -510,12 +498,6 @@
         <groupId>xmlunit</groupId>
         <artifactId>xmlunit</artifactId>
         <version>1.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guiceberry</groupId>
-        <artifactId>guiceberry</artifactId>
-        <version>3.1.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Let'd remove dependencies on Google Guice injection framework.

## Description
The pull request https://github.com/Cognifide/aet/pull/265 removed Guice usage in worker module. Now we are able to remove it from poms and we no longer need the guice for AET bundles. Some dependencies are needed for bobcat for functional tests module.

## Motivation and Context
It is enough for AET to use OSGi dependeny injection: components, services, references. For that we are using deprecated Felix SCR annotations and SCR Maven plugin, but that is something we can address in future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.