### PR TITLE
Added possibility to override name parameter from the aet client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to AET will be documented in this file.
 - [PR-260](https://github.com/Cognifide/aet/pull/260) Upgrade to Karaf 4.2.0
 - [PR-261](https://github.com/Cognifide/aet/pull/261) AET artifacts folders watched for new files
 - [PR-265](https://github.com/Cognifide/aet/pull/265) Runner simplification refactor
+- [PR-271](https://github.com/Cognifide/aet/pull/271) Added possibility to override name parameter from the aet client
 
 ## Version 2.1.5
 

--- a/client/aet-maven-plugin/src/main/java/com/cognifide/aet/plugins/maven/RunTestSuiteMojo.java
+++ b/client/aet-maven-plugin/src/main/java/com/cognifide/aet/plugins/maven/RunTestSuiteMojo.java
@@ -38,6 +38,9 @@ public class RunTestSuiteMojo extends AbstractMojo {
   @Parameter(property = "endpointDomain", defaultValue = "http://localhost:8181")
   private String endpointDomain;
 
+  @Parameter(property = "name")
+  private String name;
+
   @Parameter(property = "domain")
   private String domain;
 
@@ -58,7 +61,7 @@ public class RunTestSuiteMojo extends AbstractMojo {
     validateConfiguration();
     try {
       TestSuiteRunner testSuiteRunner = new TestSuiteRunner(endpointDomain,
-          mavenProject.getBuild().getDirectory(), timeout, domain, pattern, xUnit);
+          mavenProject.getBuild().getDirectory(), timeout, name, domain, pattern, xUnit);
       testSuiteRunner.runTestSuite(testSuite);
 
     } catch (AETException e) {

--- a/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
+++ b/client/client-core/src/main/java/com/cognifide/aet/common/TestSuiteRunner.java
@@ -58,18 +58,23 @@ public class TestSuiteRunner {
 
   private final String endpointDomain;
 
+  private final String name;
+
   private final String domain;
 
   private final String patternCorrelationId;
 
   private final boolean xUnit;
 
-  public TestSuiteRunner(String endpointDomain, String buildDirectory, int timeout, String domain,
+
+  public TestSuiteRunner(String endpointDomain, String buildDirectory, int timeout,
+      String name, String domain,
       String patternCorrelationId, boolean xUnit) {
     this.redirectWriter = new RedirectWriter(buildDirectory);
     this.buildDirectory = buildDirectory;
     this.timeout = timeout;
     this.endpointDomain = endpointDomain;
+    this.name = name;
     this.domain = domain;
     this.patternCorrelationId = patternCorrelationId;
     this.xUnit = xUnit;
@@ -126,6 +131,9 @@ public class TestSuiteRunner {
   private SuiteExecutionResult startSuiteExecution(File testSuite) {
     MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create()
         .addBinaryBody("suite", testSuite, ContentType.APPLICATION_XML, testSuite.getName());
+    if (name != null) {
+      entityBuilder.addTextBody("name", name);
+    }
     if (domain != null) {
       entityBuilder.addTextBody("domain", domain);
     }

--- a/documentation/src/main/wiki/ClientApplication.md
+++ b/documentation/src/main/wiki/ClientApplication.md
@@ -31,6 +31,7 @@ mvn aet:run -DtestSuite=FULL_PATH_TO_TEST_SUITE
 | --------- | ----------- | ------------- | --------- |
 | `testSuite` | The full path to the suite definition file (at least a file name with an extension, e.g. `testSuite.xml`).| suite.xml | no |
 | `endpointDomain` | the URL to the main AET domain | http://localhost:8181 | no |
+| `name` | Overrides the *name* parameter value from the test suite definition. | - | no |
 | `domain` | Overrides the *domain* parameter value from the test suite definition. | - | no |
 | `timeout` | Milliseconds to detect the timeout since the last status received from AET. This is useful to abort the test run if there is no activity for a long time. | 300000 (5 minutes) | no |
 | `pattern` | Id of suite that will be used as patterns source. Identical structure of pattern and current suites is assumed. | - | no |
@@ -53,6 +54,13 @@ If all URLs in your test suite point to a single domain, you can specify it so i
 ```
 mvn aet:run -DtestSuite=suite.xml -Ddomain=https://en.wikipedia.org
 ```
+
+
+If the same suite is being used to test multiple environments, you can specify the name correlated with the execution output. When the patterns *are not being shared* across multiple environments but the suite definition is the same, you may override the name, that is typically placed in the suite XML. For example:
+```
+mvn aet:run -DtestSuite=suite.xml -Dname=env-integration-suite
+```
+
 
 If you want the test run to fail if its run takes too much time, you can specify the timeout (in milliseconds) in the following way:
 ```

--- a/documentation/src/main/wiki/DefiningSuite.md
+++ b/documentation/src/main/wiki/DefiningSuite.md
@@ -56,6 +56,6 @@ The Root element for the xml definition, each test suite definition consists of 
 | `name` | Name of the test suite. It should contain lowercase letters, digits and/or characters: `-`, `_` only. | yes |
 | `company` | Name of the company. It should contain lowercase letters, digits and/or characters: `-` only.| yes |
 | `project` | Name of the project. It should contain lowercase letters, digits and/or characters: `-` only.| yes |
-| `domain` | General domain name consistent for all urls considered. Every url link is built as a concatenation of the *domain* name and the *href* attribute of it. If the `domain` property is not set, then the `href` value in the `url` definition should contain a full valid url. See more in the [Urls](../Urls) section. | no |
+| `domain` | General domain name consistent for all urls considered. Every url link is built as a concatenation of the *domain* name and the *href* attribute of it. If the `domain` property is not set, then the `href` value in the `url` definition should contain a full valid url. See more in the [[Urls]] section. | no |
 
 The `suite` element contains one or more **[[test|SuiteStructure#test]]** elements.

--- a/documentation/src/main/wiki/DefiningSuite.md
+++ b/documentation/src/main/wiki/DefiningSuite.md
@@ -56,6 +56,6 @@ The Root element for the xml definition, each test suite definition consists of 
 | `name` | Name of the test suite. It should contain lowercase letters, digits and/or characters: `-`, `_` only. | yes |
 | `company` | Name of the company. It should contain lowercase letters, digits and/or characters: `-` only.| yes |
 | `project` | Name of the project. It should contain lowercase letters, digits and/or characters: `-` only.| yes |
-| `domain` | General domain name consistent for all urls considered. Every url link is built as a concatenation of the *domain* name and the *href* attribute of it. If the `domain` property is not set, then the `href` value in the `url` definition should contain a full valid url. See more in the [[Urls|Urls]] section. | no |
+| `domain` | General domain name consistent for all urls considered. Every url link is built as a concatenation of the *domain* name and the *href* attribute of it. If the `domain` property is not set, then the `href` value in the `url` definition should contain a full valid url. See more in the [Urls](../Urls) section. | no |
 
 The `suite` element contains one or more **[[test|SuiteStructure#test]]** elements.

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
@@ -130,14 +130,15 @@ public class SuiteExecutor {
    * patterns source
    * @return status of the suite execution
    */
-  HttpSuiteExecutionResultWrapper execute(String suiteString, String domain, String pattern) {
+  HttpSuiteExecutionResultWrapper execute(String suiteString, String name, String domain,
+      String pattern) {
     SuiteRunner suiteRunner = null;
     HttpSuiteExecutionResultWrapper result;
 
     TestSuiteParser xmlFileParser = new XmlTestSuiteParser();
     try {
       TestSuiteRun testSuiteRun = xmlFileParser.parse(suiteString);
-      testSuiteRun = overrideDomainIfDefined(testSuiteRun, domain);
+      testSuiteRun = overrideDomainOrNameIfDefined(testSuiteRun, name, domain);
       testSuiteRun.setPatternCorrelationId(pattern);
 
       String validationError = suiteValidator.validateTestSuiteRun(testSuiteRun);
@@ -204,11 +205,15 @@ public class SuiteExecutor {
     return result;
   }
 
-  private TestSuiteRun overrideDomainIfDefined(TestSuiteRun testSuiteRun, String domain) {
+  private TestSuiteRun overrideDomainOrNameIfDefined(TestSuiteRun testSuiteRun, String name,
+      String domain) {
     TestSuiteRun localTestSuiteRun = testSuiteRun;
-    if (StringUtils.isNotBlank(domain)) {
+    if (StringUtils.isNotBlank(name) || StringUtils.isNotBlank(domain)) {
       List<TestRun> tests = Lists.newArrayList(localTestSuiteRun.getTestRunMap().values());
-      localTestSuiteRun = new TestSuiteRun(localTestSuiteRun, domain, tests);
+      String overriddenName = StringUtils.defaultString(name, localTestSuiteRun.getName());
+      String overridenDomain = StringUtils.defaultString(domain, localTestSuiteRun.getDomain());
+      localTestSuiteRun = new TestSuiteRun(localTestSuiteRun, overriddenName, overridenDomain,
+          tests);
     }
     return localTestSuiteRun;
   }

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
@@ -53,6 +53,7 @@ public class SuiteServlet extends HttpServlet {
   private static final Logger LOGGER = LoggerFactory.getLogger(SuiteServlet.class);
   private static final String SERVLET_PATH = "/suite";
   private static final String SUITE_PARAM = "suite";
+  private static final String NAME_PARAM = "name";
   private static final String DOMAIN_PARAM = "domain";
   private static final String PATTERN_PARAM = "pattern";
 
@@ -74,12 +75,13 @@ public class SuiteServlet extends HttpServlet {
     if (ServletFileUpload.isMultipartContent(request)) {
       Map<String, String> requestData = getRequestData(request);
       final String suite = requestData.get(SUITE_PARAM);
+      final String name = requestData.get(NAME_PARAM);
       final String domain = requestData.get(DOMAIN_PARAM);
       final String pattern = requestData.get(PATTERN_PARAM);
 
       if (StringUtils.isNotBlank(suite)) {
         HttpSuiteExecutionResultWrapper resultWrapper = suiteExecutor
-            .execute(suite, domain, pattern);
+            .execute(suite, name, domain, pattern);
         final SuiteExecutionResult suiteExecutionResult = resultWrapper.getExecutionResult();
         Gson gson = new Gson();
 

--- a/test-executor/src/main/java/com/cognifide/aet/executor/model/TestSuiteRun.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/model/TestSuiteRun.java
@@ -64,8 +64,8 @@ public class TestSuiteRun implements Serializable {
     this.testRunMap = getMap(testRunList);
   }
 
-  public TestSuiteRun(TestSuiteRun testSuiteRun, String domain, List<TestRun> tests) {
-    this.name = testSuiteRun.getName();
+  public TestSuiteRun(TestSuiteRun testSuiteRun, String name, String domain, List<TestRun> tests) {
+    this.name = name;
     this.company = testSuiteRun.getCompany();
     this.project = testSuiteRun.getProject();
     this.domain = domain;
@@ -142,9 +142,11 @@ public class TestSuiteRun implements Serializable {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("name", name).add("company", company)
-        .add("project", project)
-        .add("domain", domain).add("correlationId", correlationId)
+    return MoreObjects.toStringHelper(this)
+        .add("name", name) //
+        .add("company", company) //
+        .add("project", project) //
+        .add("domain", domain).add("correlationId", correlationId) //
         .add("version", version).toString();
   }
 


### PR DESCRIPTION
Enable reusing suite descriptor files amongst different executions

## Description
I enhanced aet-maven-plugin with the possibility to pass the overridden suite _name_ value. This parameter is now consumable by the AET web API.

## Motivation and Context
See https://github.com/Cognifide/aet/issues/256

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.