### PR TITLE
Add missing configuration policy to Runner module

### DIFF
--- a/core/runner/src/main/java/com/cognifide/aet/runner/RunnerConfiguration.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/RunnerConfiguration.java
@@ -18,6 +18,7 @@ package com.cognifide.aet.runner;
 import java.util.Map;
 import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.commons.osgi.PropertiesUtil;
@@ -29,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * between workers. This class contains all necessary configuration for the runner bundle.
  */
 @Service(RunnerConfiguration.class)
-@Component(metatype = true, description = "AET Runner Configuration", label = "AET Runner Configuration")
+@Component(metatype = true, description = "AET Runner Configuration", label = "AET Runner Configuration", policy = ConfigurationPolicy.REQUIRE)
 public class RunnerConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RunnerConfiguration.class);

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.runner.RunnerConfiguration.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.runner.RunnerConfiguration.cfg
@@ -1,0 +1,23 @@
+#
+# AET
+#
+# Copyright (C) 2013 Cognifide Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ft=120
+mttl=300
+urlPackageSize=5
+maxMessagesInCollectorQueue=20
+maxConcurrentSuitesCount=3


### PR DESCRIPTION
## Description
It is recommended approach that only one instance of Runner is available in the AET system. This configuration policy will help to achieve that by OSGi configuration.

## Motivation and Context
Easier maintenance of Runner instances in the AET cluster environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.