### PR TITLE
Fixed #70 - user now stays in the same tab while navigating around th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-289](https://github.com/Cognifide/aet/pull/289) User now stays on the same tab while navigating between URLs
 - [PR-271](https://github.com/Cognifide/aet/pull/271) Added possibility to override name parameter from the aet client
 - [PR-268](https://github.com/Cognifide/aet/pull/268) Bobcat upgrade to version 1.4.0
 - [PR-279](https://github.com/Cognifide/aet/pull/279) Upgrade for some of libraries used by AET

--- a/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
+++ b/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
@@ -142,7 +142,7 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
             if (!_.isEmpty($(suiteContainer).nextAll(
                     '.aside-report:not(.is-hidden)').first().find(
                     '.test-name'))) {
-              currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
+              currentTabLabel = getCurrentTabLabel();
               $nextElement = suiteContainer.nextAll(
                     '.aside-report:not(.is-hidden)').first();
               handleStyling(testContainer, currentItem, $nextElement);
@@ -150,7 +150,7 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
               userSettingsService.setLastTab(currentTabLabel);
             }
           } else {
-            currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
+            currentTabLabel = getCurrentTabLabel();
             userSettingsService.setLastTab(currentTabLabel);
             nextUrl.click();
             scrollTo(nextUrl);
@@ -187,7 +187,7 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
             if (!_.isEmpty($(suiteContainer).prevAll(
                   '.aside-report:not(.is-hidden)').first()
                   .find('.test-name'))) {
-              currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
+              currentTabLabel = getCurrentTabLabel();
               $previousElement = suiteContainer.prevAll(
                 '.aside-report:not(.is-hidden)').first();
               handleStyling(testContainer, currentItem, $previousElement);
@@ -195,7 +195,7 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
               userSettingsService.setLastTab(currentTabLabel);
             }
           } else {
-            currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
+            currentTabLabel = getCurrentTabLabel();
             userSettingsService.setLastTab(currentTabLabel);
             scrollTo(previousTest);
             previousTest.click();
@@ -240,6 +240,10 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
           .find('.test-url')
           .last()
           .click();
+      }
+
+      function getCurrentTabLabel() {
+        return $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
       }
 
       function clickOnTab() {

--- a/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
+++ b/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
@@ -177,7 +177,6 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
             currentLocation = window.location.hash,
             $previousElement,
             currentTab;
-
         if (!(ifRootPage(currentLocation, '/url/') || ifRootPage(
                 currentLocation, '/test/') || ifRootPage(currentLocation,
                 '/report/'))) {

--- a/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
+++ b/report/src/main/webapp/app/components/keyboardShortcuts.directive.js
@@ -121,11 +121,11 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
 
       function traverseTreeDown(currentItem, testContainer, suiteContainer,
           testUrlSelector) {
-        var currentTest,
-            currentLocation = window.location.hash,
-            $nextElement,
-            $firstElementInTest,
-            currentTabLabel;
+        var currentTest;
+        var currentLocation = window.location.hash;
+        var $nextElement;
+        var $firstElementInTest;
+        var currentTabLabel;
 
         if (!(ifRootPage(currentLocation, '/url/') || ifRootPage(
                 currentLocation, '/test/') || ifRootPage(currentLocation,
@@ -142,7 +142,7 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
             if (!_.isEmpty($(suiteContainer).nextAll(
                     '.aside-report:not(.is-hidden)').first().find(
                     '.test-name'))) {
-                      currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
+              currentTabLabel = $('.nav-tabs > .nav-item').filter('.active').text().replace(/\s/g, '');
               $nextElement = suiteContainer.nextAll(
                     '.aside-report:not(.is-hidden)').first();
               handleStyling(testContainer, currentItem, $nextElement);
@@ -168,10 +168,10 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
 
       function traverseTreeUp(currentItem, testContainer, suiteContainer,
           testUrlSelector) {
-        var previousTest,
-            currentLocation = window.location.hash,
-            $previousElement,
-            currentTabLabel;
+        var previousTest;
+        var currentLocation = window.location.hash;
+        var $previousElement;
+        var currentTabLabel;
 
         if (!(ifRootPage(currentLocation, '/url/') || ifRootPage(
                 currentLocation, '/test/') || ifRootPage(currentLocation,
@@ -268,8 +268,6 @@ define(['angularAMD', 'userSettingsService'], function (angularAMD) {
       }
 
       mutationObserver.observe(document, {
-        attributes: true,
-        characterData: true,
         childList: true,
         subtree: true,
       });

--- a/report/src/main/webapp/app/services/userSettings.service.js
+++ b/report/src/main/webapp/app/services/userSettings.service.js
@@ -28,13 +28,17 @@ define(['angularAMD', 'localStorageService'], function (angularAMD) {
           isScreenshotMaskVisible: isScreenshotMaskVisible,
           toggleScreenshotMask: toggleScreenshotMask,
           isFullSourceVisible: isFullSourceVisible,
-          toggleFullSource: toggleFullSource
+          toggleFullSource: toggleFullSource,
+          setLastTab: setLastTab,
+          getLastTab: getLastTab,
         },
         SCREENSHOT_MASK_STORAGE_KEY = 'aet:settings.visibility.screenshotMask',
         FULL_SOURCE_MASK_STORAGE_KEY = 'aet:settings.visibility.fullSource',
+        USER_TAB_MASK_STORAGE_KEY = 'aet:settings.raport.lastTab',
         settings = {
           screenshotMaskVisible: true,
-          fullSourceMaskVisible: false
+          fullSourceMaskVisible: false,
+          lastUserTab: null,
         };
 
     setupService();
@@ -45,6 +49,8 @@ define(['angularAMD', 'localStorageService'], function (angularAMD) {
           true);
       settings.fullSourceMaskVisible = getSetting(FULL_SOURCE_MASK_STORAGE_KEY,
           false);
+      settings.lastUserTab = getSetting(USER_TAB_MASK_STORAGE_KEY,
+          null);  
     }
 
     function isScreenshotMaskVisible() {
@@ -65,6 +71,14 @@ define(['angularAMD', 'localStorageService'], function (angularAMD) {
       settings.fullSourceMaskVisible = toggleSetting(
           FULL_SOURCE_MASK_STORAGE_KEY);
       return settings.fullSourceMaskVisible;
+    }
+
+    function setLastTab(val) {
+      settings.userTab = val;
+    }
+
+    function getLastTab() {
+      return settings.userTab;
     }
 
     /***************************************


### PR DESCRIPTION
User now stays in the same tab while navigating around tests tree.

## Description
Moving around the tree by using *[ ]* or arrows now automatically opens up url view instead of test view. User also stays on the same tab when moving between urls. If the same type of tab isn't found on the next/previous test url then first tab is selected.

## Motivation and Context
Fix for issue:  #70 - *Navigating between pages should remain user on the same tab*

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.