### PR TITLE
Update nu.validator version from 15.6.29 to 17.11.1

### DIFF
--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/wrapper/NuValidatorWrapper.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/wrapper/NuValidatorWrapper.java
@@ -79,14 +79,14 @@ public class NuValidatorWrapper {
 
   private void end() throws SAXException {
     errorHandler
-        .end("Document checking completed. No errors found.", "Document checking completed.");
+        .end("Document checking completed. No errors found.", "Document checking completed.", null);
   }
 
   private void setErrorHandler() {
     SourceCode sourceCode = validator.getSourceCode();
     ImageCollector imageCollector = new ImageCollector(sourceCode);
 
-    errorHandler = new MessageEmitterAdapter(sourceCode, false, imageCollector, 0, true, new
+    errorHandler = new MessageEmitterAdapter(null, sourceCode, false, imageCollector, 0, true, new
         JsonMessageEmitter(new Serializer(out), null));
     errorHandler.setErrorsOnly(errorsOnly);
   }

--- a/osgi-dependencies/aet-features.xml
+++ b/osgi-dependencies/aet-features.xml
@@ -96,9 +96,9 @@
         <bundle>wrap:mvn:org.hamcrest/hamcrest-core/1.3</bundle>
         <bundle>wrap:mvn:net.sourceforge.htmlunit/htmlunit/2.13</bundle>
         <bundle>wrap:mvn:net.sourceforge.htmlunit/htmlunit-core-js/2.13</bundle>
-        <bundle>wrap:mvn:org.apache.httpcomponents/httpclient/4.3.3</bundle>
-        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore/4.3.2</bundle>
-        <bundle>wrap:mvn:org.apache.httpcomponents/httpmime/4.3.3</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpclient/4.4</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpcore/4.4</bundle>
+        <bundle>wrap:mvn:org.apache.httpcomponents/httpmime/4.4</bundle>
         <bundle>wrap:mvn:net.jcip/jcip-annotations/1.0</bundle>
         <bundle>wrap:mvn:net.sf.jopt-simple/jopt-simple/3.2</bundle>
         <bundle>wrap:mvn:org.w3c.css/sac/1.3</bundle>

--- a/osgi-dependencies/w3chtml5validator/pom.xml
+++ b/osgi-dependencies/w3chtml5validator/pom.xml
@@ -42,7 +42,22 @@
     <dependency>
       <groupId>nu.validator</groupId>
       <artifactId>validator</artifactId>
-      <version>15.6.29</version>
+      <version>17.11.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cybozu.labs</groupId>
+      <artifactId>langdetect</artifactId>
+      <version>1.1-20120112</version>
+    </dependency>
+    <dependency>
+      <groupId>com.shapesecurity</groupId>
+      <artifactId>salvation</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>net.arnx</groupId>
+      <artifactId>jsonic</artifactId>
+      <version>1.3.9</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -52,7 +67,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>54.1.1</version>
+      <version>58.2</version>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
@@ -60,10 +75,11 @@
       <version>1.3.1</version>
     </dependency>
     <dependency>
-      <groupId>io.mola.galimatias</groupId>
+      <groupId>nu.validator</groupId>
       <artifactId>galimatias</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.2</version>
     </dependency>
+
     <dependency>
       <groupId>isorelax</groupId>
       <artifactId>isorelax</artifactId>
@@ -77,12 +93,12 @@
     <dependency>
       <groupId>nu.validator</groupId>
       <artifactId>htmlparser</artifactId>
-      <version>1.4.1</version>
+      <version>1.4.7</version>
     </dependency>
     <dependency>
       <groupId>nu.validator</groupId>
       <artifactId>jing</artifactId>
-      <version>20150629VNU</version>
+      <version>20171006VNU</version>
     </dependency>
     <dependency>
       <groupId>org.mozilla</groupId>
@@ -168,6 +184,11 @@
                   org.xmlpull.v1;resolution:=optional,
                   org.apache.xmlbeans;resolution:=optional,
                   org.apache.xerces.*;resolution:=optional,
+                  com.google.inject;resolution:=optional,
+                  org.fest.assertions;resolution:=optional,
+                  org.junit.*;resolution:=optional,
+                  org.seasar.framework.*;resolution:=optional,
+                  org.springframework.web.context.*;resolution:=optional,
                   *
                 </Import-Package>
               </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.3.3</version>
+        <version>4.4</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION

## Description
Updated nu.validator version from 15.6.29 to 17.11.1
Also added or updated dependcies of new nu.validator version.
Currently update to newest version (18.3.0) is probably not possible -
- some dependencies are throwing errors because they're compiled with Java 9

## Motivation and Context
This change will allow better (more up-to-date) validation of page source against W3C rules

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.