### PR TITLE
[#214] Filtering accessibility errors by markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to AET will be documented in this file.
 - [PR-281](https://github.com/Cognifide/aet/pull/281) No version in Bundle names (simpler deployment)
 - [PR-286](https://github.com/Cognifide/aet/pull/286) Shared Patterns - use latest patterns of given suite name ([#121](https://github.com/Cognifide/aet/issues/121))
 - [PR-291](https://github.com/Cognifide/aet/pull/291) Updated nu.validator version from 15.6.29 to 17.11.1
+- [PR-298](https://github.com/Cognifide/aet/pull/298) Filtering accessibility errors by markup CSS ([#214](https://github.com/Cognifide/aet/issues/214))
 
 ## Version 2.1.6
 

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/accessibilityfilter/AccessibilityFilterTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/accessibilityfilter/AccessibilityFilterTest.java
@@ -22,6 +22,7 @@ import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.Acces
 import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_MARKUP_CSS_SELECTOR;
 import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_PRINCIPLE;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -142,6 +143,8 @@ public class AccessibilityFilterTest {
     accessibilityFilter.modifyData(issues);
     if (exclude) {
       verify(issue).exclude();
+    } else {
+      verify(issue, never()).exclude();
     }
   }
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/accessibilityfilter/AccessibilityFilterTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/datafilters/accessibilityfilter/AccessibilityFilterTest.java
@@ -1,0 +1,148 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.job.common.datafilters.accessibilityfilter;
+
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_COLUMN;
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_ERROR;
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_ERROR_PATTERN;
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_LINE;
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_MARKUP_CSS_SELECTOR;
+import static com.cognifide.aet.job.common.datafilters.accessibilityfilter.AccessibilityFilter.PARAM_PRINCIPLE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cognifide.aet.job.api.exceptions.ParametersException;
+import com.cognifide.aet.job.api.exceptions.ProcessingException;
+import com.cognifide.aet.job.common.collectors.accessibility.AccessibilityIssue;
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.zohhak.api.Configure;
+import com.googlecode.zohhak.api.TestWith;
+import com.googlecode.zohhak.api.runners.ZohhakRunner;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+@RunWith(ZohhakRunner.class)
+@Configure(separator = "\\|")
+public class AccessibilityFilterTest {
+
+  private AccessibilityFilter accessibilityFilter;
+
+  private List<AccessibilityIssue> issues;
+
+  private AccessibilityIssue issue;
+
+  @Before
+  public void setUp() {
+    accessibilityFilter = new AccessibilityFilter();
+
+    issue = mock(AccessibilityIssue.class);
+    issues = Collections.singletonList(issue);
+  }
+
+
+  @TestWith({
+      "P1 | P1 | true",
+      "P1 | P2 | false",
+  })
+  public void modifyData_principleProvided(String errorPrinciple, String principeParam,
+      boolean exclude) throws ProcessingException, ParametersException {
+    Map<String, String> params = ImmutableMap.of(PARAM_PRINCIPLE, principeParam);
+    when(issue.getCode()).thenReturn(errorPrinciple);
+
+    setParamsAndValidate(params, exclude);
+  }
+
+
+  @TestWith({
+      "Lorem ipsum | .*ipsum.* | true",
+      "Lorem ipsum | .*dolor.* | false",
+  })
+  public void modifyData_errorPatternProvided(String errorMessage, String errorPattern,
+      boolean exclude) throws ProcessingException, ParametersException {
+    Map<String, String> params = ImmutableMap.of(PARAM_ERROR_PATTERN, errorPattern);
+    when(issue.getMessage()).thenReturn(errorMessage);
+
+    setParamsAndValidate(params, exclude);
+  }
+
+  @TestWith({
+      "Lorem ipsum | Lorem ipsum       | true",
+      "Lorem ipsum | Lorem             | false",
+      "Lorem ipsum | Lorem IPSUM       | false",
+      "Lorem ipsum | .*ipsum.*         | false",
+      "Lorem ipsum | Lorem Ipsum dolor | false"
+  })
+  public void modifyData_errorProvided(String errorMessage, String errorParam,
+      boolean exclude) throws ProcessingException, ParametersException {
+    Map<String, String> params = ImmutableMap.of(PARAM_ERROR, errorParam);
+    when(issue.getMessage()).thenReturn(errorMessage);
+
+    setParamsAndValidate(params, exclude);
+  }
+
+  @TestWith({
+      "10 | 20 | 10   | 20   | true",
+      "10 | 20 | 10   | null | true",
+      "10 | 20 | null | 20   | true",
+      "10 | 20 | 10   | null | true",
+      "10 | 20 | 10   | 21   | false",
+      "10 | 20 | 11   | 20   | false",
+  })
+  public void modifyData_positionProvided(Integer line, Integer column, Integer lineParam,
+      Integer columnParam, boolean exclude) throws ProcessingException, ParametersException {
+    Map<String, String> params = new HashMap<>();
+    if (lineParam != null) {
+      params.put(PARAM_LINE, lineParam.toString());
+    }
+    if (columnParam != null) {
+      params.put(PARAM_COLUMN, columnParam.toString());
+    }
+    when(issue.getLineNumber()).thenReturn(line);
+    when(issue.getColumnNumber()).thenReturn(column);
+    
+    setParamsAndValidate(params, exclude);
+  }
+
+  @TestWith({
+      "<form><input type='text' class='form-control'></form> | form              | true",
+      "<form><input type='text' class='form-control'></form> | [type=text]       | true",
+      "<form><input type='text' class='form-control'></form> | .form-control     | true",
+      "<form><input type='text' class='form-control'></form> | form.form-control | false",
+      "<form><input type='text' class='form-control'></form> | .foo              | false",
+  })
+  public void modifyData_markupCssSelectorProvided(String markup, String markupCss,
+      boolean exclude) throws ParametersException, ProcessingException {
+    Map<String, String> params = ImmutableMap.of(PARAM_MARKUP_CSS_SELECTOR, markupCss);
+    when(issue.getElementString()).thenReturn(markup);
+    setParamsAndValidate(params, exclude);
+  }
+
+
+  private void setParamsAndValidate(Map<String, String> params, boolean exclude)
+      throws ParametersException, ProcessingException {
+    accessibilityFilter.setParameters(params);
+    accessibilityFilter.modifyData(issues);
+    if (exclude) {
+      verify(issue).exclude();
+    }
+  }
+}
+

--- a/documentation/src/main/wiki/AccessibilityDataFilter.md
+++ b/documentation/src/main/wiki/AccessibilityDataFilter.md
@@ -17,6 +17,7 @@ Resource name: accessibility
 | `principle` | string principle | The exact accessibility issue principle |
 | `line` | integer line number |The line number in the file which the issue occurred in |
 | `column` | integer column number | The column number in the file which the issue occurred is |
+| `markupCss` | CSS selector | CSS selector matching the HTML fragment where the issue was detected |
 
 *Note:*
 - `error` will be overridden by `errorPattern` if set.
@@ -51,6 +52,7 @@ In this example the exact match of the accessibility issue breaking principle "W
                 <accessibility-filter line="252" />
                 <accessibility-filter column="6" />
                 <accessibility-filter line="317" column="50" />
+                <accessibility-filter markupCss=".form-control" />
             </accessibility>
             ...
         </compare>

--- a/integration-tests/test-suite/partials/accessibility-filtered.xml
+++ b/integration-tests/test-suite/partials/accessibility-filtered.xml
@@ -82,6 +82,21 @@
 		</urls>
 	</test>
 
+	<test name="F-comparator-accessibility-with-standard-wcag2a-filtered-only-by-markup-css">
+		<collect>
+			<open />
+			<accessibility standard="WCAG2A" />
+		</collect>
+		<compare>
+			<accessibility>
+				<accessibility-filter markupCss=".form-control" />
+			</accessibility>
+		</compare>
+		<urls>
+			<url href="comparators/accessibility/failed.jsp" />
+		</urls>
+	</test>
+
 	<test name="S-comparator-accessibility-with-standard-wcag2a-filtered-all">
 		<collect>
 			<open />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added possibility to filter accessibility errors by markup using a CSS selector.

## Motivation and Context
See #214 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.