### PR TITLE
Timeout-based integration tests stabilization for Chrome

### DIFF
--- a/integration-tests/sample-site/src/main/webapp/sanity/modifiers/sleep/failed.jsp
+++ b/integration-tests/sample-site/src/main/webapp/sanity/modifiers/sleep/failed.jsp
@@ -28,7 +28,7 @@ java.util.Date date = new java.util.Date();
 	</div>
 </div>
 <script>
-	setTimeout(function(){ document.getElementById("date-panel").style.display = 'none'; }, 3000);
+	setTimeout(function(){ document.getElementById("date-panel").style.display = 'none'; }, 10000);
 </script>
 <%@ include file="/includes/bodyContent.jsp" %>
 <%@ include file="/includes/footer.jsp" %>

--- a/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-element-to-be-visible/element-will-cover-timestamp.jsp
+++ b/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-element-to-be-visible/element-will-cover-timestamp.jsp
@@ -25,7 +25,7 @@
 	</div>
 </div>
 <script>
-	setTimeout(function(){ document.getElementById("test-element").style.display = ''; }, 4000);
+	setTimeout(function(){ document.getElementById("test-element").style.display = ''; }, 8000);
 </script>
 
 <%

--- a/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-image-completion/image-will-cover-timestamp.jsp
+++ b/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-image-completion/image-will-cover-timestamp.jsp
@@ -25,7 +25,7 @@
     </div>
 </div>
 <script>
-    setTimeout(function(){ document.getElementById("test-element").style.display = ''; }, 4000);
+    setTimeout(function(){ document.getElementById("test-element").style.display = ''; }, 11000);
 </script>
 
 <%

--- a/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-page-loaded/delay.jsp
+++ b/integration-tests/sample-site/src/main/webapp/sanity/modifiers/wait-for-page-loaded/delay.jsp
@@ -59,6 +59,6 @@
 				elementToChange.innerHTML = 'Final Text That is displayed after timeout while page elements are still loading.';
 			}
 			++COUNTER;
-		}, t * 600);
+		}, t * 1000);
 	}
 </script>

--- a/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
+++ b/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
@@ -29,9 +29,9 @@ import org.junit.runner.RunWith;
 @Modules(GuiceModule.class)
 public class HomePageTilesTest {
 
-  private static final int TESTS = 113;
+  private static final int TESTS = 115;
 
-  private static final int EXPECTED_TESTS_SUCCESS = 66;
+  private static final int EXPECTED_TESTS_SUCCESS = 68;
 
   private static final int EXPECTED_TESTS_WARN = 5;
 

--- a/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
+++ b/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
@@ -37,8 +37,8 @@ Feature: Tests Results Filtering
   Scenario: Filtering Tests Results: layout
     Given I have opened sample tests report page
     When I search for tests containing "layout"
-    Then There are 13 tiles visible
-    And Statistics text contains "13 ( 3 / 0 / 10 / 0 )"
+    Then There are 15 tiles visible
+    And Statistics text contains "15 ( 4 / 0 / 11 / 0 )"
 
    Scenario: Filtering Tests Results: jserrors
     Given I have opened sample tests report page
@@ -98,4 +98,4 @@ Feature: Tests Results Filtering
     Given I have opened sample tests report page
     When I search for tests containing "wait-for-image-completion"
     Then There are 4 tiles visible
-    And Statistics text contains "4 ( 2 / 0 / 2 / 0 )"
+    And Statistics text contains "4 ( 1 / 0 / 3 / 0 )"

--- a/integration-tests/test-suite/partials/sleep-modifier.xml
+++ b/integration-tests/test-suite/partials/sleep-modifier.xml
@@ -25,7 +25,7 @@
 		<collect>
 			<open />
 			<resolution width="1500" />
-			<sleep duration="6000" />
+			<sleep duration="10000" />
 			<screen />
 		</collect>
 		<compare>

--- a/integration-tests/test-suite/partials/wait-for-element-to-be-visible.xml
+++ b/integration-tests/test-suite/partials/wait-for-element-to-be-visible.xml
@@ -25,7 +25,7 @@
 		<collect>
 			<open />
 			<resolution width="1500" />
-			<wait-for-element-to-be-visible css="#test-element" timeout = "6000"/>
+			<wait-for-element-to-be-visible css="#test-element" timeout = "10000"/>
 			<screen />
 		</collect>
 		<compare>

--- a/integration-tests/test-suite/partials/wait-for-image-completion.xml
+++ b/integration-tests/test-suite/partials/wait-for-image-completion.xml
@@ -24,7 +24,7 @@
 	<test name="S-modifier-Wait-For-Image-Completion">
 		<collect>
 			<open />
-			<resolution width="1500" />
+			<resolution width="1500" height="800"/>
 			<wait-for-image-completion xpath="//img[@id = 'image-to-wait-for']" timeout = "15000"/>
 			<screen />
 		</collect>
@@ -39,8 +39,8 @@
 	<test name="F-modifier-Wait-For-Image-Completion-not-visible">
 		<collect>
 			<open />
-            <resolution width="1500" />
-			<wait-for-image-completion css="#image-to-wait-for" timeout = "100"/>
+			<resolution width="1500" />
+			<wait-for-image-completion css="#image-to-wait-for" timeout="100"/>
 			<screen />
 		</collect>
 		<compare>
@@ -54,7 +54,7 @@
 	<test name="S-modifier-Wait-For-Image-Completion-slow-image">
 		<collect>
 			<open />
-            <resolution width="1500" />
+			<resolution width="1500" />
 			<!-- image is served with additional latency -->
 			<wait-for-image-completion css="#image-to-wait-for" timeout = "7000"/>
 			<screen />
@@ -67,11 +67,12 @@
 		</urls>
 	</test>
 
-	<test name="F-modifier-Wait-For-Image-Completion-slow-image">
+	<!-- Should pass because Chrome waits for images in the <open> phase -->
+	<test name="S-modifier-Wait-For-Image-Completion-slow-image-short-timeout">
 		<collect>
 			<open />
 			<!-- image is served with additional latency -->
-			<wait-for-image-completion xpath="//img[@id = 'image-to-wait-for']" timeout = "3000"/>
+			<wait-for-image-completion xpath="//img[@id = 'image-to-wait-for']" timeout = "1"/>
 			<screen />
 		</collect>
 		<compare>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Modified timeouts on Sample Site and Test Suite.
to fix tests results for SeleniumGrid+Chrome migration.
Updated functional (Bobcat) tests.

## Motivation and Context
In codebase there are some tests which are expected e.g. to take a screenshot before some timeout-based javascript code is executed on a page. To get the same test results on Selenium Grid + Chrome setup, those timeouts need to be increased - it seems that Chromedriver needs more time to complete the `open` phase (than the old Firefox, without Selenium Grid) - by default it's using `normal` [page load strategy](https://www.w3.org/TR/webdriver/#dfn-table-of-page-load-strategies)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.