### PR TITLE
Default web driver changed from Firefox to Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-327](https://github.com/Cognifide/aet/pull/327) Default web driver changed from Firefox to Chrome
 - [PR-294](https://github.com/Cognifide/aet/pull/294) Added support for full page screenshot in chrome
 - [PR-293](https://github.com/Cognifide/aet/pull/293) Added error treshold in pixels and percentages for screen comparator
 - [PR-300](https://github.com/Cognifide/aet/pull/300) Added creating indexes for collection

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/WebDriverProvider.java
@@ -47,7 +47,7 @@ public class WebDriverProvider {
 
   private static final String DEFAULT_WEB_DRIVER_NAME = "defaultWebDriverName";
 
-  @Property(name = DEFAULT_WEB_DRIVER_NAME, label = "Default Web Driver name", value = "ff")
+  @Property(name = DEFAULT_WEB_DRIVER_NAME, label = "Default Web Driver name", value = "chrome")
   private String defaultWebDriverName;
 
   @Reference(referenceInterface = WebDriverFactory.class, policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE, bind = "bindWebDriverFactory", unbind = "unbindWebDriverFactory")

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/ChromeWebDriverFactory.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/ChromeWebDriverFactory.java
@@ -55,7 +55,6 @@ import org.osgi.framework.Constants;
 
 @Service
 @Component(
-    policy = ConfigurationPolicy.REQUIRE,
     description = "AET Chrome WebDriver Factory",
     label = "AET Chrome WebDriver Factory",
     metatype = true)

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -7,3 +7,15 @@ You may see all changes in the [Changelog](https://github.com/Cognifide/aet/blob
 
 ## Unreleased
 
+### BrowserMob Proxy server connection  
+  The address of BrowserMob Proxy server is set to `localhost:8080` by default (in Karaf config) - 
+  it's used by workers to connect to the proxy server. Previously, when tests were being run on local Firefox instances
+  running on the same machine as the proxy server, there was no need to change the default config.
+  Currently, when tests are executed on Selenium Grid nodes on different machines, the address of proxy 
+  server must be configured  to an IP/host name which is accessible for the nodes. 
+  It can be configured in `com.cognifide.aet.proxy.RestProxyManager.cfg` file - default config for Vagrant is:
+  ```
+  server=192.168.123.100
+  port=8080
+  ```
+  

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.proxy.RestProxyManager.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.proxy.RestProxyManager.cfg
@@ -1,0 +1,20 @@
+#
+# AET
+#
+# Copyright (C) 2013 Cognifide Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server=192.168.123.100
+port=8080


### PR DESCRIPTION

## Description
Default web driver changed from Firefox to Chrome. Added RestProxyManager configuration file for local development (on vagrant). Added UpgradeNotes entry to explain the need to change  RestProxyManager configuration in new AET version.

## Motivation and Context
When some environment is using default settings or when someone starts a new AET instance (e.g. on vagrant), we want the tests to be working on Chrome web driver by default.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.