### PR TITLE
Enable creating new dbs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to AET will be documented in this file.
 - [PR-296](https://github.com/Cognifide/aet/pull/296) Status Code Comparator now checks range 400-600 by default, parameters validation added
 - [PR-325](https://github.com/Cognifide/aet/pull/325) Support env variables in report manager
 - [PR-331](https://github.com/Cognifide/aet/pull/325) Support env variables in MongoDB config
+- [PR-338](https://github.com/Cognifide/aet/pull/338) Enable creating new dbs by default
 
 ## Version 2.1.6
 

--- a/core/datastorage/src/main/java/com/cognifide/aet/vs/mongodb/configuration/MongoDBClientConf.java
+++ b/core/datastorage/src/main/java/com/cognifide/aet/vs/mongodb/configuration/MongoDBClientConf.java
@@ -35,7 +35,7 @@ public @interface MongoDBClientConf {
 
   String ALLOW_AUTO_CREATE_PROPERTY_DESCRIPTION = "Allows automatic creation of DB if set to true";
 
-  boolean DEFAULT_AUTOCREATE_VALUE = false;
+  boolean DEFAULT_AUTOCREATE_VALUE = true;
 
   @AttributeDefinition(name = MONGO_URI_PROPERTY_NAME, description = MONGO_URI_PROPERTY_DESCRIPTION, type = AttributeType.STRING)
   String mongoURI() default "";


### PR DESCRIPTION
## Description
Changed default config of the `MongoDBClient` to enable creating databases.

## Motivation and Context
Since #300 AET automatically creates indexes for databases created automatically. Enabled creating new DBs is more user-friendly approach.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.