### PR TITLE
Add designate to default jms connection

### DIFF
--- a/core/communication/src/main/java/com/cognifide/aet/queues/DefaultJmsConnection.java
+++ b/core/communication/src/main/java/com/cognifide/aet/queues/DefaultJmsConnection.java
@@ -27,10 +27,12 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Component(immediate = true)
+@Designate(ocd = DefaultJmsConnectionConf.class)
 public class DefaultJmsConnection implements JmsConnection {
 
   private static final boolean SESSION_TRANSACTION_DEFAULT_SETTING = false;


### PR DESCRIPTION
Designate decorator was ommited in https://github.com/Cognifide/aet/pull/326. We need it for karaf configuration.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.