### PR TITLE
Height for resolution modifier on pages with dynamically changing height

### DIFF
--- a/integration-tests/test-suite/partials/sleep-modifier.xml
+++ b/integration-tests/test-suite/partials/sleep-modifier.xml
@@ -24,7 +24,7 @@
 	<test name="S-modifier-Sleep">
 		<collect>
 			<open />
-			<resolution width="1500" />
+			<resolution width="1500" height="2800" />
 			<sleep duration="10000" />
 			<screen />
 		</collect>
@@ -39,7 +39,7 @@
 	<test name="F-modifier-Sleep">
 		<collect>
 			<open />
-			<resolution width="1500" />
+			<resolution width="1500" height="2800" />
 			<sleep duration="100" />
 			<screen />
 		</collect>

--- a/integration-tests/test-suite/partials/wait-for-page-loaded-modifier.xml
+++ b/integration-tests/test-suite/partials/wait-for-page-loaded-modifier.xml
@@ -24,7 +24,7 @@
 	<test name="S-modifier-Wait-For-Page-Loaded">
 		<collect>
 			<open />
-			<resolution width="1500" />
+			<resolution width="1500" height="3150"/>
 			<wait-for-page-loaded />
 			<screen />
 		</collect>
@@ -39,7 +39,7 @@
 	<test name="F-modifier-Wait-For-Page-Loaded">
 		<collect>
 			<open />
-			<resolution width="1500" />
+			<resolution width="1500" height="3150"/>
 			<!-- needed for initial timestamp rendering on Vagrant -->
 			<sleep duration="100" />
 			<screen />


### PR DESCRIPTION
## Description
Specified height for resolution modifier on pages with dynamically changing height

## Motivation and Context
Some pages on sanity-site are dynamically changing its height after <open> phase - the resolution modifier is sometimes calulcating the page height at different moment and the screen comparator are detecting unwanted difference.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.