### PR TITLE
[#351] Disable nu.validator language detection to fix random NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-359](https://github.com/Cognifide/aet/pull/359) ([#351](https://github.com/Cognifide/aet/issues/351)) Disabled nu.validator language detection to fix random NPE
+
 ## Version 3.0.0
 
 

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/wrapper/NuValidatorWrapper.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/wrapper/NuValidatorWrapper.java
@@ -55,7 +55,7 @@ public class NuValidatorWrapper {
   private void setupAndValidate(InputStream sourceStream) throws ProcessingException {
     System.setProperty("nu.validator.datatype.warn", "true");
     out = new ByteArrayOutputStream();
-    validator = new SimpleDocumentValidator();
+    validator = createValidatorWithDisabledLanguageDetection();
     try {
       setup();
       validator.checkHtmlInputSource(new InputSource(sourceStream));
@@ -63,6 +63,13 @@ public class NuValidatorWrapper {
     } catch (SAXException | IOException e) {
       throw new ProcessingException(e.getMessage(), e);
     }
+  }
+
+  private SimpleDocumentValidator createValidatorWithDisabledLanguageDetection() {
+    boolean initializeLog4j = true;
+    boolean logUrls = true;
+    boolean enableLanguageDetection = false;
+    return new SimpleDocumentValidator(initializeLog4j, logUrls, enableLanguageDetection);
   }
 
   private void setup() throws ProcessingException, SAXException {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`enableLanguageDetection` flag set to false for `SimpleDocumentValidator` object (NuValidator).

## Motivation and Context
Related issue: https://github.com/Cognifide/aet/issues/351

Following error is sometimes thrown in worker logs:
```
2018-09-17T12:31:59,018 | ERROR | com.cognifide.aet.worker | ComparatorDispatcherImpl           68 | Comparator{type=source, filters=[], parameters={comparator=w3c-html5}} throw error:
com.cognifide.aet.job.api.exceptions.ProcessingException: null
        at com.cognifide.aet.job.common.comparators.w3chtml5.W3cHtml5Comparator.compare(W3cHtml5Comparator.java:75) ~[?:?]
        at com.cognifide.aet.worker.impl.ComparatorDispatcherImpl.run(ComparatorDispatcherImpl.java:66) [52:com.cognifide.aet.worker:3.0.0]
        at com.cognifide.aet.worker.listeners.ComparatorMessageListenerImpl.onMessage(ComparatorMessageListenerImpl.java:95) [52:com.cognifide.aet.worker:3.0.0]
        at org.apache.activemq.ActiveMQMessageConsumer.dispatch(ActiveMQMessageConsumer.java:1404) [127:org.apache.activemq.activemq-osgi:5.15.2]
        at org.apache.activemq.ActiveMQSessionExecutor.dispatch(ActiveMQSessionExecutor.java:131) [127:org.apache.activemq.activemq-osgi:5.15.2]
        at org.apache.activemq.ActiveMQSessionExecutor.iterate(ActiveMQSessionExecutor.java:202) [127:org.apache.activemq.activemq-osgi:5.15.2]
        at org.apache.activemq.thread.PooledTaskRunner.runTask(PooledTaskRunner.java:133) [127:org.apache.activemq.activemq-osgi:5.15.2]
        at org.apache.activemq.thread.PooledTaskRunner$1.run(PooledTaskRunner.java:48) [127:org.apache.activemq.activemq-osgi:5.15.2]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
Caused by: java.lang.NullPointerException
        at com.cybozu.labs.langdetect.DetectorFactory.addProfile(DetectorFactory.java:135) ~[?:?]
        at com.cybozu.labs.langdetect.DetectorFactory.loadProfile(DetectorFactory.java:108) ~[?:?]
        at nu.validator.xml.LanguageDetectingXMLReaderWrapper.initialize(LanguageDetectingXMLReaderWrapper.java:188) ~[?:?]
        at nu.validator.validation.SimpleDocumentValidator.<init>(SimpleDocumentValidator.java:218) ~[?:?]
        at nu.validator.validation.SimpleDocumentValidator.<init>(SimpleDocumentValidator.java:154) ~[?:?]
        at com.cognifide.aet.job.common.comparators.w3chtml5.wrapper.NuValidatorWrapper.setupAndValidate(NuValidatorWrapper.java:58) ~[?:?]
        at com.cognifide.aet.job.common.comparators.w3chtml5.wrapper.NuValidatorWrapper.validate(NuValidatorWrapper.java:48) ~[?:?]
        at com.cognifide.aet.job.common.comparators.w3chtml5.W3cHtml5Comparator.compare(W3cHtml5Comparator.java:70) ~[?:?]
```
We don't know the root cause of this error and it's hard to provide any reproduction steps - it seems like it's randomly thrown for few different URLs for some test suites. The error is thrown in the language detection library (dependency of nu validator) - disabling this feature seems to be fixing the issue.

## Screenshots (if appropriate):
![aet w3c nullpointerexception](https://user-images.githubusercontent.com/8331703/45692865-1942e580-bb5c-11e8-99e3-3e58693206ed.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.