### PR TITLE
Convert JMX message ttl from sec to millis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-364](https://github.com/Cognifide/aet/pull/364) Fixed bug (which appeared in 3.0.0) with missing conversion from seconds to millisecond for JMX message TTL. 
+
 ## Version 3.0.1
 
 

--- a/core/runner/src/main/java/com/cognifide/aet/runner/RunnerConfiguration.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/RunnerConfiguration.java
@@ -16,6 +16,7 @@
 package com.cognifide.aet.runner;
 
 import com.cognifide.aet.runner.configuration.RunnerConfigurationConf;
+import java.util.concurrent.TimeUnit;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -33,13 +34,13 @@ public class RunnerConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RunnerConfiguration.class);
 
-  private static RunnerConfigurationConf config;
+  private RunnerConfigurationConf config;
 
   @Activate
   public void activate(RunnerConfigurationConf config) {
     this.config = config;
     LOGGER.info(
-        "Runner configured with parameters: [ft: {} sec ; mttl: {} ; urlPackageSize: {} ; maxMessagesInCollectorQueue: {}; maxConcurrentSuitesCount: {}.]",
+        "Runner configured with parameters: [ft: {} sec ; mttl: {} sec ; urlPackageSize: {} ; maxMessagesInCollectorQueue: {}; maxConcurrentSuitesCount: {}.]",
         config.ft(), config.mttl(), config.urlPackageSize(), config.maxMessagesInCollectorQueue(),
         config.maxConcurrentSuitesCount());
 
@@ -55,10 +56,10 @@ public class RunnerConfiguration {
 
 
   /**
-   * @return time in seconds after which messages will be thrown out of queues.
+   * @return time in milliseconds after which messages will be thrown out of queues.
    */
   public long getMttl() {
-    return config.mttl();
+    return TimeUnit.SECONDS.toMillis(config.mttl());
   }
 
 

--- a/core/runner/src/test/java/com/cognifide/aet/runner/RunnerConfigurationTest.java
+++ b/core/runner/src/test/java/com/cognifide/aet/runner/RunnerConfigurationTest.java
@@ -1,0 +1,32 @@
+package com.cognifide.aet.runner;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.cognifide.aet.runner.configuration.RunnerConfigurationConf;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RunnerConfigurationTest {
+
+  private RunnerConfiguration runnerConfiguration;
+
+  @Mock
+  private RunnerConfigurationConf config;
+
+  @Test
+  public void getMttl_whenOsgiConfigReturnsSeconds_expectMilliseconds() {
+    long mttlInSeconds = 300L;
+    long mttlInMilliseconds = 300000L;
+
+    when(config.mttl()).thenReturn(mttlInSeconds);
+    runnerConfiguration = new RunnerConfiguration();
+    runnerConfiguration.activate(config);
+
+    assertThat(runnerConfiguration.getMttl(), equalTo(mttlInMilliseconds));
+  }
+}

--- a/core/runner/src/test/java/com/cognifide/aet/runner/RunnerConfigurationTest.java
+++ b/core/runner/src/test/java/com/cognifide/aet/runner/RunnerConfigurationTest.java
@@ -1,3 +1,18 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.cognifide.aet.runner;
 
 import static org.hamcrest.CoreMatchers.equalTo;


### PR DESCRIPTION
## Description
Restore convertion from sec to millis for JMX message TTL

## Motivation and Context
Before [PR-326](https://github.com/Cognifide/aet/pull/326) was merged, message TTL configured in OSGi in seconds was converted to milliseconds in RunnerConfiguration class. This convertion was omitted during migration to new OSGI annotations and this PR brings it back.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.