### PR TITLE
OSGI-configurable chrome options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-378](https://github.com/Cognifide/aet/pull/378) OSGI-configurable Chrome options.
+
 ## Version 3.0.0
 
 

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/ChromeWebDriverFactory.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/ChromeWebDriverFactory.java
@@ -112,9 +112,7 @@ public class ChromeWebDriverFactory implements WebDriverFactory {
     capabilities.setCapability(CapabilityType.LOGGING_PREFS, loggingPreferences);
 
     ChromeOptions options = new ChromeOptions();
-    options.addArguments("--disable-plugins");
-    options.addArguments("--headless");
-    options.addArguments("--hide-scrollbars");
+    options.addArguments(config.chromeOptions());
     options.setAcceptInsecureCerts(true);
 
     capabilities.setCapability(ChromeOptions.CAPABILITY, options);

--- a/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/configuration/ChromeWebDriverFactoryConf.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/drivers/chrome/configuration/ChromeWebDriverFactoryConf.java
@@ -37,4 +37,8 @@ public @interface ChromeWebDriverFactoryConf {
       name = SELENIUM_GRID_URL_LABEL,
       description = SELENIUM_GRID_URL_LABEL)
   String seleniumGridUrl() default DEFAULT_SELENIUM_GRID_URL;
+
+  @AttributeDefinition(name = "Chrome options")
+  String[] chromeOptions() default
+      { "--disable-plugins", "--headless", "--hide-scrollbars", "--disable-gpu" } ;
 }

--- a/documentation/src/main/wiki/AdvancedSetup.md
+++ b/documentation/src/main/wiki/AdvancedSetup.md
@@ -81,3 +81,7 @@ of Apache server which hosts the AET Report application - e.g. `http://aet-repor
 | Consumer queue name | Fixed value `AET.comparatorJobs` |
 | Producer queue name | Fixed value `AET.comparatorResults` |
 
+##### Chrome options configuration
+
+The `AET Chrome WebDriver Factory` component configuration (`chromeOptions` property) allows you to configure a list of options/arguments 
+which will be passed to the Chrome browser binary. The default list of Chrome options is: `--disable-plugins`, `--headless`, `--hide-scrollbars`, `--disable-gpu`.

--- a/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
+++ b/osgi-dependencies/configs/src/main/resources/com.cognifide.aet.worker.drivers.chrome.ChromeWebDriverFactory.cfg
@@ -1,0 +1,27 @@
+#
+# AET
+#
+# Copyright (C) 2013 Cognifide Limited
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name = "chrome"
+seleniumGridUrl = "http://localhost:4444/wd/hub"
+chromeOptions = [ \
+  "--disable-plugins", \
+  "--headless", \
+  "--hide-scrollbars", \
+  "--disable-gpu", \
+  ]
+


### PR DESCRIPTION
## Description
Chrome options (i.e. chrome run arguments) can now be configured in OSGi (ChromeWebDriverFactory component).

## Motivation and Context
Using different sets of chrome options may help us to achieve screenshot consistency (e.g. by hiding scrollbars) or solve different stability/timeout issues when running Selenium Grid node with Chromedriver - e.g. see this stackoverflow thread as an example: https://stackoverflow.com/a/52340526 . OSGI configuration will enable us to easily change the chrome options when e.g. upgrading to newer chromedriver version will require it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.