### PR TITLE
[#379] Exclude elements position calculated with partial screenshot offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 
+- [PR-380](https://github.com/Cognifide/aet/pull/380) Exclude elements position calculated with partial screenshot offset ([#379](https://github.com/Cognifide/aet/issues/379))
 - [PR-378](https://github.com/Cognifide/aet/pull/378) OSGI-configurable Chrome options.
 
 ## Version 3.0.0

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
@@ -70,15 +70,18 @@ public class ScreenCollector extends WebElementsLocatorParams implements Collect
     this.artifactsDAO = artifactsDAO;
   }
 
-  private List<ExcludedElement> getExcludeElementsFromWebElements(
-      List<WebElement> webElements) {
+  private List<ExcludedElement> getExcludeElementsFromWebElements(List<WebElement> webElements) {
     List<ExcludedElement> excludeExcludedElements = new ArrayList<>(webElements.size());
+
+    Point screenshotOffset = isSelectorPresent() ?
+        webDriver.findElement(getLocator()).getLocation() : new Point(0, 0);
     for (WebElement webElement : webElements) {
-      java.awt.Point point = new java.awt.Point(webElement.getLocation().x,
-          webElement.getLocation().y);
-      java.awt.Dimension dimension = new java.awt.Dimension(webElement.getSize().width,
-          webElement.getSize().height);
-      excludeExcludedElements.add(new ExcludedElement(point, dimension));
+      Point point = webElement.getLocation()
+          .moveBy(-screenshotOffset.getX(), -screenshotOffset.getY());
+
+      excludeExcludedElements.add(new ExcludedElement(
+          new java.awt.Point(point.getX(), point.getY()),
+          new java.awt.Dimension(webElement.getSize().width, webElement.getSize().height)));
     }
     return excludeExcludedElements;
   }

--- a/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
+++ b/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
@@ -29,15 +29,15 @@ import org.junit.runner.RunWith;
 @Modules(GuiceModule.class)
 public class HomePageTilesTest {
 
-  private static final int TESTS = 132;
+  private static final int TESTS = 136;
 
-  private static final int EXPECTED_TESTS_SUCCESS = 75;
+  private static final int EXPECTED_TESTS_SUCCESS = 77;
 
-  private static final int EXPECTED_TESTS_CONDITIONALLY_PASSED = 7;
+  private static final int EXPECTED_TESTS_CONDITIONALLY_PASSED = 9;
 
   private static final int EXPECTED_TESTS_WARN = 5;
 
-  private static final int EXPECTED_TESTS_FAIL = 52;
+  private static final int EXPECTED_TESTS_FAIL = 54;
 
   @Inject
   private ReportHomePage page;

--- a/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
+++ b/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
@@ -37,8 +37,8 @@ Feature: Tests Results Filtering
   Scenario: Filtering Tests Results: layout
     Given I have opened sample tests report page
     When I search for tests containing "layout"
-    Then There are 31 tiles visible
-    And Statistics text contains "31 ( 13 / 0 / 18 (7) / 0 )"
+    Then There are 35 tiles visible
+    And Statistics text contains "35 ( 15 / 0 / 20 (9) / 0 )"
 
    Scenario: Filtering Tests Results: jserrors
     Given I have opened sample tests report page

--- a/integration-tests/test-suite/partials/layout.xml
+++ b/integration-tests/test-suite/partials/layout.xml
@@ -414,5 +414,65 @@
 			<url href="comparators/layout/failed.jsp"/>
 		</urls>
 	</test>
+
+  <test name="S-comparator-Layout-Partial-with-Exclude">
+    <collect>
+      <open/>
+      <resolution width="767" height="300"/>
+      <sleep duration="3000"/>
+      <screen css=".dynamic1" exclude-elements=".dynamic1" />
+    </collect>
+    <compare>
+      <screen comparator="layout"/>
+    </compare>
+    <urls>
+      <url href="comparators/layout/failed.jsp"/>
+    </urls>
+  </test>
+
+  <test name="S-comparator-Layout-Auto-Height-Partial-with-Exclude">
+    <collect>
+      <open/>
+      <resolution width="767"/>
+      <sleep duration="3000"/>
+      <screen css=".space" exclude-elements=".dynamic1,.dynamic2" />
+    </collect>
+    <compare>
+      <screen comparator="layout"/>
+    </compare>
+    <urls>
+      <url href="comparators/layout/height_detection.jsp"/>
+    </urls>
+  </test>
+
+  <test name="F-comparator-Layout-Auto-Height-Partial-with-Exclude">
+    <collect>
+      <open/>
+      <resolution width="767"/>
+      <sleep duration="3000"/>
+      <screen css=".space" exclude-elements=".dynamic2" />
+    </collect>
+    <compare>
+      <screen comparator="layout"/>
+    </compare>
+    <urls>
+      <url href="comparators/layout/height_detection.jsp"/>
+    </urls>
+  </test>
+
+  <test name="F-comparator-Layout-Partial-with-Exclude-outside-partial">
+    <collect>
+      <open/>
+      <resolution width="767" height="300"/>
+      <sleep duration="3000"/>
+      <screen css=".dynamic2" exclude-elements=".dynamic1" />
+    </collect>
+    <compare>
+      <screen comparator="layout"/>
+    </compare>
+    <urls>
+      <url href="comparators/layout/failed.jsp"/>
+    </urls>
+  </test>
 	<!-- Layout-Comparator END -->
 </suite>


### PR DESCRIPTION
## Description
Exclude elements position calculated with partial screenshot offset

## Motivation and Context
See #379

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.