### PR TITLE
Hotfix/screen max height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ All notable changes to AET will be documented in this file.
 
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
+- [PR-387](https://github.com/Cognifide/aet/pull/387) Set max allowed page screenshot height to 35k pixels.
 
 ## Version 3.0.1
 
 
 - [PR-380](https://github.com/Cognifide/aet/pull/380) Exclude elements position calculated with partial screenshot offset ([#379](https://github.com/Cognifide/aet/issues/379))
 - [PR-378](https://github.com/Cognifide/aet/pull/378) OSGI-configurable Chrome options.
-- [PR-387](https://github.com/Cognifide/aet/pull/387) Set max allowed page screenshot height to 35k pixels.
 
 ## Version 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to AET will be documented in this file.
 
 - [PR-380](https://github.com/Cognifide/aet/pull/380) Exclude elements position calculated with partial screenshot offset ([#379](https://github.com/Cognifide/aet/issues/379))
 - [PR-378](https://github.com/Cognifide/aet/pull/378) OSGI-configurable Chrome options.
-- [PR-enter pr no. here](https://github.com/Cognifide/aet/pull/prNumber) Set max allowed page screenshot height to 35k pixels.
+- [PR-387](https://github.com/Cognifide/aet/pull/387) Set max allowed page screenshot height to 35k pixels.
 
 ## Version 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to AET will be documented in this file.
 
 - [PR-380](https://github.com/Cognifide/aet/pull/380) Exclude elements position calculated with partial screenshot offset ([#379](https://github.com/Cognifide/aet/issues/379))
 - [PR-378](https://github.com/Cognifide/aet/pull/378) OSGI-configurable Chrome options.
+- [PR-enter pr no. here](https://github.com/Cognifide/aet/pull/prNumber) Set max allowed page screenshot height to 35k pixels.
 
 ## Version 3.0.0
 

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/modifiers/resolution/ResolutionModifier.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/modifiers/resolution/ResolutionModifier.java
@@ -41,7 +41,7 @@ public class ResolutionModifier implements CollectorJob {
 
   private static final String JAVASCRIPT_GET_BODY_HEIGHT = "return document.body.scrollHeight";
 
-  private static final int MAX_SIZE = 15000;
+  private static final int MAX_SIZE = 35000;
 
   private static final int INITIAL_HEIGHT = 300;
 

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/modifiers/resolution/ResolutionModifierTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/modifiers/resolution/ResolutionModifierTest.java
@@ -53,7 +53,7 @@ public class ResolutionModifierTest {
 
   private static final int CUSTOM_HEIGHT = 600;
 
-  private static final int BROWSER_HEIGHT_LIMIT = 15000;
+  private static final int BROWSER_HEIGHT_LIMIT = 35000;
 
   @Mock
   private RemoteWebDriver webDriver;

--- a/documentation/src/main/wiki/ResolutionModifier.md
+++ b/documentation/src/main/wiki/ResolutionModifier.md
@@ -12,8 +12,8 @@ Module name: **resolution**
 
 | Parameter | Value | Description | Mandatory |
 | --------- | ----- | ----------- | --------- |
-| `width` | int (1 to 15000) | Window width | yes |
-| `height` | int (1 to 15000) | Window height | no |
+| `width` | int (1 to 35000) | Window width | yes |
+| `height` | int (1 to 35000) | Window height | no |
 
 | Note |
 |:------ |

--- a/integration-tests/sample-site/src/main/webapp/sanity/comparators/layout/long_page.jsp
+++ b/integration-tests/sample-site/src/main/webapp/sanity/comparators/layout/long_page.jsp
@@ -1,0 +1,27 @@
+<%--
+
+    AET
+
+    Copyright (C) 2013 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+--%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ include file="/includes/header.jsp" %>
+<c:forEach begin="1" end="30" varStatus="loop">
+  <div class="sponsor" style="height: 1000px">
+    <img src="/sample-site/assets/demo_files/logo.png" alt="Bootswatch" />
+  </div>
+</c:forEach>
+<%@ include file="dynamic_content.jsp" %>

--- a/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
+++ b/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
@@ -29,15 +29,15 @@ import org.junit.runner.RunWith;
 @Modules(GuiceModule.class)
 public class HomePageTilesTest {
 
-  private static final int TESTS = 136;
+  private static final int TESTS = 138;
 
-  private static final int EXPECTED_TESTS_SUCCESS = 77;
+  private static final int EXPECTED_TESTS_SUCCESS = 78;
 
-  private static final int EXPECTED_TESTS_CONDITIONALLY_PASSED = 9;
+  private static final int EXPECTED_TESTS_CONDITIONALLY_PASSED = 10;
 
   private static final int EXPECTED_TESTS_WARN = 5;
 
-  private static final int EXPECTED_TESTS_FAIL = 54;
+  private static final int EXPECTED_TESTS_FAIL = 55;
 
   @Inject
   private ReportHomePage page;

--- a/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
+++ b/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
@@ -37,8 +37,8 @@ Feature: Tests Results Filtering
   Scenario: Filtering Tests Results: layout
     Given I have opened sample tests report page
     When I search for tests containing "layout"
-    Then There are 35 tiles visible
-    And Statistics text contains "35 ( 15 / 0 / 20 (9) / 0 )"
+    Then There are 37 tiles visible
+    And Statistics text contains "37 ( 16 / 0 / 21 (10) / 0 )"
 
    Scenario: Filtering Tests Results: jserrors
     Given I have opened sample tests report page

--- a/integration-tests/test-suite/partials/layout.xml
+++ b/integration-tests/test-suite/partials/layout.xml
@@ -479,6 +479,8 @@
 		<collect>
 			<open/>
 			<resolution width="767"/>
+			<!--ToDo: Remove resolution-sleep-resolution workaround after issue #357 is fixed.
+			(https://github.com/Cognifide/aet/issues/357)-->
 			<sleep duration="2000"/>
 			<resolution width="767"/>
 			<screen css=".dynamic2"/>
@@ -495,6 +497,8 @@
 		<collect>
 			<open/>
 			<resolution width="767"/>
+			<!--ToDo: Remove resolution-sleep-resolution workaround after issue #357 is fixed.
+			(https://github.com/Cognifide/aet/issues/357)-->
 			<sleep duration="2000"/>
 			<resolution width="767"/>
 			<screen exclude-elements=".dynamic1,.dynamic2"/>

--- a/integration-tests/test-suite/partials/layout.xml
+++ b/integration-tests/test-suite/partials/layout.xml
@@ -483,7 +483,7 @@
 			(https://github.com/Cognifide/aet/issues/357)-->
 			<sleep duration="2000"/>
 			<resolution width="767"/>
-			<screen css=".dynamic2"/>
+			<screen/>
 		</collect>
 		<compare>
 			<screen comparator="layout"/>

--- a/integration-tests/test-suite/partials/layout.xml
+++ b/integration-tests/test-suite/partials/layout.xml
@@ -474,5 +474,38 @@
       <url href="comparators/layout/failed.jsp"/>
     </urls>
   </test>
+
+	<test name="F-comparator-Layout-dynamic-element-at-bottom-of-long-page">
+		<collect>
+			<open/>
+			<resolution width="767"/>
+			<sleep duration="2000"/>
+			<resolution width="767"/>
+			<screen css=".dynamic2"/>
+		</collect>
+		<compare>
+			<screen comparator="layout"/>
+		</compare>
+		<urls>
+			<url href="comparators/layout/long_page.jsp"/>
+		</urls>
+	</test>
+
+	<test name="S-comparator-Layout-long-page-without-dynamic-at-bottom">
+		<collect>
+			<open/>
+			<resolution width="767"/>
+			<sleep duration="2000"/>
+			<resolution width="767"/>
+			<screen exclude-elements=".dynamic1,.dynamic2"/>
+		</collect>
+		<compare>
+			<screen comparator="layout"/>
+		</compare>
+		<urls>
+			<url href="comparators/layout/long_page.jsp"/>
+		</urls>
+	</test>
+
 	<!-- Layout-Comparator END -->
 </suite>


### PR DESCRIPTION
Change max allowed screenshot pixels height to 35k.

## Description
After lowering of max allowed screenshot height from 100k to 15k, some projects were unable to test some of their long pages. After testing, this pr changes the value to 35k pixels.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.