### PR TITLE
Add new regex param sourcePattern to js errors data filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 - [PR-387](https://github.com/Cognifide/aet/pull/387) Set max allowed page screenshot height to 35k pixels.
+- [PR-prNumber](https://github.com/Cognifide/aet/pull/prNumber) Added new regex param `sourcePattern` to [JS Errors Data Filter](https://github.com/Cognifide/aet/wiki/JSErrorsDataFilter)
 
 ## Version 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 - [PR-387](https://github.com/Cognifide/aet/pull/387) Set max allowed page screenshot height to 35k pixels.
-- [PR-prNumber](https://github.com/Cognifide/aet/pull/prNumber) Added new regex param `sourcePattern` to [JS Errors Data Filter](https://github.com/Cognifide/aet/wiki/JSErrorsDataFilter)
+- [PR-401](https://github.com/Cognifide/aet/pull/401) Added new regex param `sourcePattern` to [JS Errors Data Filter](https://github.com/Cognifide/aet/wiki/JSErrorsDataFilter)
 
 ## Version 3.0.1
 

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/datafilters/jserrorsfilter/JsErrorsFilter.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/datafilters/jserrorsfilter/JsErrorsFilter.java
@@ -36,6 +36,8 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
 
   private static final String PARAM_SOURCE = "source";
 
+  private static final String PARAM_SOURCE_PATTERN = "sourcePattern";
+
   private static final String PARAM_LINE = "line";
 
   private String errorMessage;
@@ -43,6 +45,8 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
   private Pattern errorMessagePattern;
 
   private String sourceFile;
+
+  private Pattern sourceFilePattern;
 
   private Integer line;
 
@@ -52,8 +56,10 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
     errorMessagePattern = ParamsHelper.getParamAsPattern(PARAM_ERROR_PATTERN, params);
     line = ParamsHelper.getParamAsInteger(PARAM_LINE, params);
     sourceFile = ParamsHelper.getParamAsString(PARAM_SOURCE, params);
+    sourceFilePattern = ParamsHelper.getParamAsPattern(PARAM_SOURCE_PATTERN, params);
 
-    ParamsHelper.atLeastOneIsProvided(errorMessage, errorMessagePattern, sourceFile, line);
+    ParamsHelper.atLeastOneIsProvided(
+            errorMessage, errorMessagePattern, sourceFile, sourceFilePattern, line);
   }
 
   /**
@@ -75,8 +81,8 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
   }
 
   private boolean shouldBeIgnored(JsErrorLog jse) {
-    String source = jse.getSourceName();
-    return shouldExcludeRegardingSource(source)
+    return ParamsHelper.matches(sourceFilePattern, jse.getSourceName())
+        && shouldExcludeRegardingSource(jse.getSourceName())
         && ParamsHelper.matches(errorMessagePattern, jse.getErrorMessage())
         && (errorMessage == null || errorMessage.equals(jse.getErrorMessage()))
         && ParamsHelper.equalOrNotSet(line, jse.getLineNumber());
@@ -84,11 +90,13 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
 
   private void addErrorInfo(JsErrorLog errorLog) {
     String errorPattern = errorMessagePattern == null ? null : errorMessagePattern.toString();
+    String sourcePattern = sourceFilePattern == null ? null : sourceFilePattern.toString();
 
     FilterInfo filterInfo = new FilterInfo()
         .add(PARAM_ERROR, errorMessage)
         .add(PARAM_ERROR_PATTERN, errorPattern)
         .add(PARAM_SOURCE, sourceFile)
+        .add(PARAM_SOURCE_PATTERN, sourcePattern)
         .add(PARAM_LINE, line);
     errorLog.addMatchedFilter(filterInfo);
   }
@@ -111,6 +119,7 @@ public class JsErrorsFilter extends AbstractDataModifierJob<Set<JsErrorLog>> {
     return NAME + " DataModifier with parameters: "
         + PARAM_ERROR_PATTERN + ": " + errorMessagePattern + " "
         + PARAM_SOURCE + ": " + sourceFile + " "
+        + PARAM_SOURCE_PATTERN + ": " + sourceFilePattern + " "
         + PARAM_LINE + ": " + line;
   }
 

--- a/documentation/src/main/wiki/JSErrorsDataFilter.md
+++ b/documentation/src/main/wiki/JSErrorsDataFilter.md
@@ -17,6 +17,7 @@ Resource name: js-errors
 | --------- | ----- | ----------- | --------- |
 |`error`|string error|Exact error message|At least one of parameter is required|
 |`source`|JavaScript filename suffix (see notes) below|Source file name in which error occurred|At least one of parameter is required|
+|`sourcePattern`|JavaScript filename pattern|Regular expression that matches source file name in which error occurred|At least one of parameter is required|
 |`errorPattern` | pattern error text | Regular expression that matches message text of issue to be filter out|At least one parameter is required|
 |`line`  integer line number|Line number in file in which error occurred| |At least one of parameter is required|
 

--- a/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
+++ b/integration-tests/sanity-functional/src/test/java/com/cognifide/aet/sanity/functional/HomePageTilesTest.java
@@ -29,15 +29,15 @@ import org.junit.runner.RunWith;
 @Modules(GuiceModule.class)
 public class HomePageTilesTest {
 
-  private static final int TESTS = 138;
+  private static final int TESTS = 140;
 
-  private static final int EXPECTED_TESTS_SUCCESS = 78;
+  private static final int EXPECTED_TESTS_SUCCESS = 79;
 
   private static final int EXPECTED_TESTS_CONDITIONALLY_PASSED = 10;
 
   private static final int EXPECTED_TESTS_WARN = 5;
 
-  private static final int EXPECTED_TESTS_FAIL = 55;
+  private static final int EXPECTED_TESTS_FAIL = 56;
 
   @Inject
   private ReportHomePage page;

--- a/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
+++ b/integration-tests/sanity-functional/src/test/resources/features/filtering.feature
@@ -43,8 +43,8 @@ Feature: Tests Results Filtering
    Scenario: Filtering Tests Results: jserrors
     Given I have opened sample tests report page
     When I search for tests containing "jserrors"
-    Then There are 14 tiles visible
-    And Statistics text contains "14 ( 6 / 0 / 8 (0) / 0 )"
+    Then There are 16 tiles visible
+    And Statistics text contains "16 ( 7 / 0 / 9 (0) / 0 )"
     
   Scenario: Filtering Tests Results: source
     Given I have opened sample tests report page

--- a/integration-tests/test-suite/partials/js-errors-filter-by-sourcePattern.xml
+++ b/integration-tests/test-suite/partials/js-errors-filter-by-sourcePattern.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    AET
+
+    Copyright (C) 2013 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<suite name="main" company="aet" domain="http://192.168.123.100:9090/sample-site/sanity/" project="aet">
+  <test name="S-comparator-JsErrors-all-errors-filtered">
+    <collect>
+      <open />
+      <sleep duration="2000" />
+      <js-errors />
+    </collect>
+    <compare>
+      <js-errors>
+        <js-errors-filter sourcePattern=".*failed.jsp" />
+      </js-errors>
+    </compare>
+    <urls>
+      <url href="comparators/jserrors/failed.jsp" />
+    </urls>
+  </test>
+
+  <test name="F-comparator-JsErrors-no-errors-filtered">
+    <collect>
+      <open />
+      <sleep duration="2000" />
+      <js-errors />
+    </collect>
+    <compare>
+      <js-errors>
+        <js-errors-filter sourcePattern=".*non-existing-source.*" />
+      </js-errors>
+    </compare>
+    <urls>
+      <url href="comparators/jserrors/failed.jsp" />
+    </urls>
+  </test>
+</suite>

--- a/integration-tests/test-suite/test-suite-assembly.xsl
+++ b/integration-tests/test-suite/test-suite-assembly.xsl
@@ -27,6 +27,7 @@
 			<xsl:apply-templates select="document('partials/js-errors-filter-by-error.xml')/*/test"/>
 			<xsl:apply-templates select="document('partials/js-errors-filter-by-errorPattern.xml')/*/test"/>
 			<xsl:apply-templates select="document('partials/js-errors-filter-by-source-and-line.xml')/*/test"/>
+			<xsl:apply-templates select="document('partials/js-errors-filter-by-sourcePattern.xml')/*/test"/>
 			<xsl:apply-templates select="document('partials/status-codes.xml')/*/test"/>
 			<xsl:apply-templates select="document('partials/w3c-html5.xml')/*/test"/>
 			<xsl:apply-templates select="document('partials/w3c-html5-filtered.xml')/*/test"/>


### PR DESCRIPTION
## Description
Basically adds new param that allows filtering js errors source by regex.

## Motivation and Context
Fixed #356 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.