### PR TITLE
Switch to the latest aet-cookbook 5.1.1 with fixed mongo folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to AET will be documented in this file.
 ## Unreleased
 **List of changes that are finished but not yet released in any final version.**
 - [PR-412](https://github.com/Cognifide/aet/pull/412) ([PR-336](https://github.com/Cognifide/aet/pull/336), [PR-337](https://github.com/Cognifide/aet/pull/337), [PR-395](https://github.com/Cognifide/aet/pull/395)) - Added rerun functionality for suite, test and url 
+- [PR-429](https://github.com/Cognifide/aet/pull/429) - `aet-cookbook` version updated to [`v5.1.1`](https://github.com/Cognifide/aet-cookbook/blob/master/CHANGELOG.md#511) in Vagrant. **Important**: please follow the instructions from [PR-43 description](https://github.com/Cognifide/aet-cookbook/pull/43) in order to keep the MongoDB data on your local environment.
 
 ## Version 3.1.0
 

--- a/vagrant/metadata.rb
+++ b/vagrant/metadata.rb
@@ -24,4 +24,4 @@ description      'Installs/Configures aet-vagrant'
 long_description 'Installs/Configures aet-vagrant'
 version          '2.1.6'
 
-depends 'aet', '~> 5.1.0'
+depends 'aet', '~> 5.1.1'


### PR DESCRIPTION
## Description
After fixing https://github.com/Cognifide/aet-cookbook/issues/42 in `aet-cookbook` Vagrant environment needs to be updated.

## Motivation and Context
Fix bug from aet-cookbook in local Vagrant instances.
 
**Important**: in order to keep the data, please follow https://github.com/Cognifide/aet-cookbook/pull/43 instructions on your local virtual machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code style](https://github.com/Cognifide/aet/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the AET Contributor License Agreement.