### PR TITLE
Some additional unit tests for source formatter

### DIFF
--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult.Status;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.common.ArtifactDAOMock;
 import com.cognifide.aet.job.common.comparators.AbstractComparatorTest;
@@ -95,6 +96,35 @@ public class SourceComparatorTest extends AbstractComparatorTest {
         "markup/data-source-with-different-attribute-value.html",
         ImmutableMap.of("compareType", "markup"));
     assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+  }
 
+  @Test
+  public void shouldRecognizeLineEndings() throws Exception {
+    //When
+    result = compare("formatting/empty-lines-windows.html",
+        "formatting/empty-lines-linux.html",
+        ImmutableMap.of("compareType", "all"));
+    //Then
+    assertEquals(Status.FAILED, result.getStatus());
+  }
+
+  @Test
+  public void shouldIgnoreLineEndingsForAllFormatted() throws Exception {
+    //When
+    result = compare("formatting/empty-lines-windows.html",
+        "formatting/empty-lines-linux.html",
+        ImmutableMap.of("compareType", "allformatted"));
+    //Then
+    assertEquals(Status.PASSED, result.getStatus());
+  }
+
+  @Test
+  public void shouldIgnoreWhitespacesForAllFormatted() throws Exception {
+    //When
+    result = compare("formatting/formatted.html",
+        "formatting/not-formatted.html",
+        ImmutableMap.of("compareType", "allformatted"));
+    //Then
+    assertEquals(Status.PASSED, result.getStatus());
   }
 }

--- a/core/jobs/src/test/resources/mock/SourceComparator/formatting/empty-lines-linux.html
+++ b/core/jobs/src/test/resources/mock/SourceComparator/formatting/empty-lines-linux.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>title</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+
+
+<div>
+  <span>zażółć</span>
+
+</div>
+
+
+</body>
+</html>

--- a/core/jobs/src/test/resources/mock/SourceComparator/formatting/empty-lines-windows.html
+++ b/core/jobs/src/test/resources/mock/SourceComparator/formatting/empty-lines-windows.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>title</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+
+
+<div>
+  <span>zażółć</span>
+
+</div>
+
+
+</body>
+</html>

--- a/core/jobs/src/test/resources/mock/SourceComparator/formatting/formatted.html
+++ b/core/jobs/src/test/resources/mock/SourceComparator/formatting/formatted.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>title</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+<div>
+  <span>zażółć</span>
+</div>
+</body>
+</html>

--- a/core/jobs/src/test/resources/mock/SourceComparator/formatting/not-formatted.html
+++ b/core/jobs/src/test/resources/mock/SourceComparator/formatting/not-formatted.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+<title>title</title>
+
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js"></script>
+</head>
+<body>
+
+<div>
+
+
+  <span>zażółć</span>
+
+
+  </div>
+        </body>
+</html>
+
+
+
+
+
+


### PR DESCRIPTION
Just a proposition: I added few tests for ALLFORMATTED mode for source comparator

## Description
Only few tests to see if code is properly formatted.
By the way: JSoup parser always wraps the code with <HTML><HEAD> ... <BODY> ... :)

## Motivation and Context
We didn't have tests for this mode before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
