### PR TITLE
Bugfix/accessibility duplicates

### DIFF
--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityCollector.java
@@ -28,6 +28,8 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -64,6 +66,7 @@ public class AccessibilityCollector implements CollectorJob {
         .getExecutionResultAsString();
     final String json = jsExecutor.execute(script, standard).getExecutionResultAsString();
     List<AccessibilityIssue> issues = parseIssues(json);
+    HashMap<AccessibilityIssue, Integer> issuesCount = fetchIssuesCount(issues);
     getElementsPositions(issues, html);
 
     String resultId = artifactsDAO.saveArtifactInJsonFormat(properties, issues);
@@ -100,6 +103,12 @@ public class AccessibilityCollector implements CollectorJob {
     Type list = new TypeToken<List<AccessibilityIssue>>() {
     }.getType();
     return gson.fromJson(json, list);
+  }
+
+  private HashMap<AccessibilityIssue, Integer> fetchIssuesCount(List<AccessibilityIssue> issues) {
+    HashMap<AccessibilityIssue, Integer> map = new LinkedHashMap<>();
+    issues.forEach(issue -> map.put(issue, map.getOrDefault(issue, 0) + 1));
+    return map;
   }
 
   private void getElementsPositions(List<AccessibilityIssue> issues, final String html) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityIssue.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityIssue.java
@@ -17,6 +17,7 @@ package com.cognifide.aet.job.common.collectors.accessibility;
 
 import com.cognifide.aet.job.common.Excludable;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class AccessibilityIssue implements Serializable, Excludable {
 
@@ -95,6 +96,27 @@ public class AccessibilityIssue implements Serializable, Excludable {
   @Override
   public void exclude() {
     this.excluded = true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AccessibilityIssue that = (AccessibilityIssue) o;
+    return type == that.type &&
+        Objects.equals(message, that.message) &&
+        Objects.equals(code, that.code) &&
+        Objects.equals(elementString, that.elementString) &&
+        Objects.equals(elementStringAbbreviated, that.elementStringAbbreviated);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, message, code, elementString, elementStringAbbreviated);
   }
 
   public enum IssueType {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityIssue.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/accessibility/AccessibilityIssue.java
@@ -108,7 +108,6 @@ public class AccessibilityIssue implements Serializable, Excludable {
     }
     AccessibilityIssue that = (AccessibilityIssue) o;
     return type == that.type &&
-        Objects.equals(message, that.message) &&
         Objects.equals(code, that.code) &&
         Objects.equals(elementString, that.elementString) &&
         Objects.equals(elementStringAbbreviated, that.elementStringAbbreviated);
@@ -116,7 +115,7 @@ public class AccessibilityIssue implements Serializable, Excludable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, message, code, elementString, elementStringAbbreviated);
+    return Objects.hash(type, code, elementString, elementStringAbbreviated);
   }
 
   public enum IssueType {


### PR DESCRIPTION
Fix line and column numbers duplicating in reports when multiple elements have the same HTML. (related to #438)

## Description
My implementation scans document HTML starting from the latest occurrence of the same issue and not from the beginning of the document.
---
I hereby agree to the terms of the AET Contributor License Agreement.
