### PR TITLE
Feature/accepting multiple patterns

### DIFF
--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Comparator.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Comparator.java
@@ -29,7 +29,7 @@ public class Comparator extends Operation implements Commentable, Named {
 
   public static final String COMPARATOR_PARAMETER = "comparator";
 
-  private ComparatorStepResult stepResult;
+  private List<ComparatorStepResult> stepResults;
 
   private List<Operation> filters = new ArrayList<>();
 
@@ -41,16 +41,16 @@ public class Comparator extends Operation implements Commentable, Named {
     super(type);
   }
 
-  public ComparatorStepResult getStepResult() {
-    return stepResult;
+  public List<ComparatorStepResult> getStepResults() {
+    return stepResults;
   }
 
-  public void setStepResult(ComparatorStepResult stepResult) {
-    this.stepResult = stepResult;
+  public void setStepResults(List<ComparatorStepResult> stepResults) {
+    this.stepResults = stepResults;
   }
 
   public List<Operation> getFilters() {
-    if(filters == null){
+    if (filters == null) {
       return Collections.emptyList();
     }
     return ImmutableList.copyOf(filters);

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Comparator.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Comparator.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 
 public class Comparator extends Operation implements Commentable, Named {
 
-  private static final long serialVersionUID = -2641455400847109851L;
+  private static final long serialVersionUID = -2641455409327109851L;
 
   public static final String COMPARATOR_PARAMETER = "comparator";
 

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/ComparatorStepResult.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/ComparatorStepResult.java
@@ -19,7 +19,7 @@ import javax.validation.Valid;
 
 public class ComparatorStepResult extends StepResult {
 
-  private static final long serialVersionUID = 4112741834952534050L;
+  private static final long serialVersionUID = 4112700984952534120L;
 
   private final Status status;
 

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/ComparatorStepResult.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/ComparatorStepResult.java
@@ -15,6 +15,8 @@
  */
 package com.cognifide.aet.communication.api.metadata;
 
+import javax.validation.Valid;
+
 public class ComparatorStepResult extends StepResult {
 
   private static final long serialVersionUID = 4112741834952534050L;
@@ -25,16 +27,21 @@ public class ComparatorStepResult extends StepResult {
 
   private final boolean acceptable;
 
+  @Valid
+  private final Pattern pattern;
+
   public ComparatorStepResult(String artifactId, Status status) {
-    this(artifactId, status, false);
+    this(artifactId, null, status, false);
   }
 
-  public ComparatorStepResult(String artifactId, Status status, Boolean rebaseable) {
+  public ComparatorStepResult(String artifactId, Pattern pattern, Status status,
+      Boolean rebaseable) {
     super(artifactId);
     this.status = status;
     this.rebaseable = rebaseable;
     this.acceptable = rebaseable &&
         (Status.FAILED.equals(status) || Status.CONDITIONALLY_PASSED.equals(status));
+    this.pattern = pattern;
   }
 
   @Override

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
@@ -1,0 +1,49 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.communication.api.metadata;
+
+import java.util.Objects;
+
+public class Pattern {
+
+  @javax.validation.constraints.Pattern(regexp = "^[0-9a-fA-F]{24}$", message = "Invalid objectID")
+  private final String pattern;
+
+  public Pattern(String pattern) {
+    this.pattern = pattern;
+  }
+
+  public String getPattern() {
+    return pattern;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Pattern pattern1 = (Pattern) o;
+    return Objects.equals(pattern, pattern1.pattern);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pattern);
+  }
+}

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
@@ -15,10 +15,14 @@
  */
 package com.cognifide.aet.communication.api.metadata;
 
+import java.io.Serializable;
 import java.util.Objects;
 import org.hibernate.validator.constraints.NotBlank;
 
-public class Pattern {
+public class Pattern implements Serializable {
+
+  private static final long serialVersionUID = 4009233984951235127L;
+
 
   @javax.validation.constraints.Pattern(regexp = "^[0-9a-fA-F]{24}$", message = "Invalid objectID")
   private final String pattern;

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Pattern.java
@@ -16,18 +16,27 @@
 package com.cognifide.aet.communication.api.metadata;
 
 import java.util.Objects;
+import org.hibernate.validator.constraints.NotBlank;
 
 public class Pattern {
 
   @javax.validation.constraints.Pattern(regexp = "^[0-9a-fA-F]{24}$", message = "Invalid objectID")
   private final String pattern;
 
-  public Pattern(String pattern) {
+  @NotBlank
+  private final String patternSuiteCorrelationId;
+
+  public Pattern(String pattern, String patternSuiteCorrelationId) {
     this.pattern = pattern;
+    this.patternSuiteCorrelationId = patternSuiteCorrelationId;
   }
 
   public String getPattern() {
     return pattern;
+  }
+
+  public String getPatternSuiteCorrelationId() {
+    return patternSuiteCorrelationId;
   }
 
   @Override

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
@@ -17,11 +17,13 @@ package com.cognifide.aet.communication.api.metadata;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.NotBlank;
 
 public class Step extends Operation implements Commentable, Named {
@@ -34,8 +36,8 @@ public class Step extends Operation implements Commentable, Named {
   @NotBlank
   private String name;
 
-  @Pattern(regexp = "^[0-9a-fA-F]{24}$", message = "Invalid objectID")
-  private String pattern;
+  @Valid
+  private Set<Pattern> patterns;
 
   @Valid
   private CollectorStepResult stepResult;
@@ -51,7 +53,7 @@ public class Step extends Operation implements Commentable, Named {
     super(builder.type);
     index = builder.index;
     name = builder.name;
-    pattern = builder.pattern;
+    patterns = builder.patterns;
     stepResult = builder.stepResult;
     setComment(builder.comment);
     comparators = builder.comparators;
@@ -70,8 +72,15 @@ public class Step extends Operation implements Commentable, Named {
     return index;
   }
 
-  public String getPattern() {
-    return pattern;
+  public Set<Pattern> getPatterns() {
+    if (patterns == null) {
+      patterns = new HashSet<>();
+    }
+    return patterns;
+  }
+
+  public void erasePatterns() {
+    patterns = null;
   }
 
   public void setStepResult(CollectorStepResult stepResult) {
@@ -99,8 +108,19 @@ public class Step extends Operation implements Commentable, Named {
     comparators.add(comparator);
   }
 
-  public void updatePattern(String artifactId) {
-    this.pattern = artifactId;
+  public void addPatterns(String... artifactId) {
+    Set<Pattern> patterns = Arrays.stream(artifactId)
+        .map(Pattern::new)
+        .collect(Collectors.toSet());
+    addPatterns(patterns);
+  }
+
+  public void addPatterns(Set<Pattern> patterns) {
+    if (this.patterns == null) {
+      this.patterns = new HashSet<>();
+    }
+
+    this.patterns.addAll(patterns);
   }
 
   @Override
@@ -156,12 +176,11 @@ public class Step extends Operation implements Commentable, Named {
 
     private final String type;
     private String name;
-    private String pattern;
+    private Set<Pattern> patterns;
     private CollectorStepResult stepResult;
     private String comment;
     private Set<Comparator> comparators = new HashSet<>();
     private Integer index;
-
 
     private Builder(String type, Integer index) {
       this.type = type;
@@ -173,8 +192,8 @@ public class Step extends Operation implements Commentable, Named {
       return this;
     }
 
-    public Builder withPattern(String val) {
-      pattern = val;
+    public Builder withPatterns(Set<Pattern> val) {
+      patterns = val;
       return this;
     }
 

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
@@ -108,18 +108,15 @@ public class Step extends Operation implements Commentable, Named {
     comparators.add(comparator);
   }
 
-  public void addPatterns(String... artifactId) {
-    Set<Pattern> patterns = Arrays.stream(artifactId)
-        .map(Pattern::new)
-        .collect(Collectors.toSet());
-    addPatterns(patterns);
+  public void addPattern(String artifactId, String patternSuiteCorrelationId) {
+    Pattern pattern = new Pattern(artifactId, patternSuiteCorrelationId);
+    addPatterns(Collections.singleton(pattern));
   }
 
   public void addPatterns(Set<Pattern> patterns) {
     if (this.patterns == null) {
       this.patterns = new HashSet<>();
     }
-
     this.patterns.addAll(patterns);
   }
 

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Step.java
@@ -28,7 +28,7 @@ import org.hibernate.validator.constraints.NotBlank;
 
 public class Step extends Operation implements Commentable, Named {
 
-  private static final long serialVersionUID = 3123747091786941360L;
+  private static final long serialVersionUID = 3437740998451941360L;
 
   @NotNull
   private final Integer index;

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/StepResult.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/StepResult.java
@@ -32,7 +32,6 @@ public abstract class StepResult implements Serializable {
   private static final long serialVersionUID = 7757386595499766654L;
 
   @Pattern(regexp = "^[0-9a-fA-F]{24}$", message = "Invalid objectID")
-
   private final String artifactId;
 
   private final Payload payload;

--- a/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Suite.java
+++ b/api/communication-api/src/main/java/com/cognifide/aet/communication/api/metadata/Suite.java
@@ -87,16 +87,16 @@ public class Suite implements Serializable, Commentable, Named, Validatable {
   @Valid
   private final List<Test> tests = new ArrayList<>();
 
-  private final String patternCorrelationId;
+  private final Set<String> patternCorrelationIds;
 
   public Suite(String correlationId, String company, String project, String name,
-      String patternCorrelationId) {
+      Set<String> patternCorrelationIds) {
     this.correlationId = correlationId;
     this.company = company;
     this.project = project;
     this.name = name;
     this.runTimestamp = new Timestamp(System.currentTimeMillis());
-    this.patternCorrelationId = patternCorrelationId;
+    this.patternCorrelationIds = patternCorrelationIds;
   }
 
   public String getCorrelationId() {
@@ -132,10 +132,10 @@ public class Suite implements Serializable, Commentable, Named, Validatable {
     return tests;
   }
 
-  public Optional<Test> getTest(String testName){
+  public Optional<Test> getTest(String testName) {
     Test testToReturn = null;
-    for (Test test: this.tests) {
-      if(test.getName().equals(testName)){
+    for (Test test : this.tests) {
+      if (test.getName().equals(testName)) {
         testToReturn = test;
         break;
       }
@@ -155,8 +155,8 @@ public class Suite implements Serializable, Commentable, Named, Validatable {
     this.runTimestamp = runTimestamp;
   }
 
-  public String getPatternCorrelationId() {
-    return patternCorrelationId;
+  public Set<String> getPatternCorrelationIds() {
+    return patternCorrelationIds;
   }
 
   public void setStatistics(Statistics statistics) {

--- a/api/communication-api/src/test/resources/metadata/suite-with-two-sleeps.json
+++ b/api/communication-api/src/test/resources/metadata/suite-with-two-sleeps.json
@@ -1,31 +1,31 @@
 {
-  "correlationId" : "unittest-project-0",
-  "company" : "unittest",
-  "project" : "project",
-  "name" : "unitTestingSuite",
-  "version" : 1,
+  "correlationId": "unittest-project-0",
+  "company": "unittest",
+  "project": "project",
+  "name": "unitTestingSuite",
+  "version": 1,
   "runTimestamp": {
     "value": 0
   },
-  "tests" : [
+  "tests": [
     {
-      "name" : "test-one",
-      "comment" : "test level comment",
-      "urls" : [
+      "name": "test-one",
+      "comment": "test level comment",
+      "urls": [
         {
-          "name" : "/our-company",
-          "url" : "/our-company",
-          "canonicalUrl" : "/our-company",
-          "domain" : "https://cognifide.com",
-          "comment" : "url level comment",
-          "steps" : [
+          "name": "/our-company",
+          "url": "/our-company",
+          "canonicalUrl": "/our-company",
+          "domain": "https://cognifide.com",
+          "comment": "url level comment",
+          "steps": [
             {
-              "index" : 0,
-              "name" : "open",
-              "stepResult" : {
-                "status" : "PAGE_OPENED"
+              "index": 0,
+              "name": "open",
+              "stepResult": {
+                "status": "PAGE_OPENED"
               },
-              "type" : "open"
+              "type": "open"
             },
             {
               "index": 1,
@@ -39,29 +39,31 @@
               }
             },
             {
-              "index" : 2,
-              "name" : "desktop",
-              "comment" : "step level comment",
-              "pattern" : "56ebbed87346a042e67ef462",
-              "stepResult" : {
-                "status" : "COLLECTED",
-                "artifactId" : "56ebbed87346a042e67ef462"
+              "index": 2,
+              "name": "desktop",
+              "comment": "step level comment",
+              "pattern": "56ebbed87346a042e67ef462",
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56ebbed87346a042e67ef462"
               },
-              "comparators" : [
+              "comparators": [
                 {
-                  "comment" : "screen comparator level comment",
-                  "stepResult" : {
-                    "status" : "PASSED"
-                  },
-                  "type" : "screen",
-                  "parameters" : {
-                    "comparator" : "layout"
+                  "comment": "screen comparator level comment",
+                  "stepResult": [
+                    {
+                      "status": "PASSED"
+                    }
+                  ],
+                  "type": "screen",
+                  "parameters": {
+                    "comparator": "layout"
                   }
                 }
               ],
-              "type" : "screen",
-              "parameters" : {
-                "name" : "desktop"
+              "type": "screen",
+              "parameters": {
+                "name": "desktop"
               }
             },
             {
@@ -76,33 +78,35 @@
               }
             },
             {
-              "index" : 4,
-              "name" : "source",
-              "pattern" : "56f3b0a978139e1e6dabcd0e",
-              "stepResult" : {
-                "status" : "COLLECTED",
-                "artifactId" : "56f3b0a978139e1e6dabcd0e"
+              "index": 4,
+              "name": "source",
+              "pattern": "56f3b0a978139e1e6dabcd0e",
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56f3b0a978139e1e6dabcd0e"
               },
-              "comparators" : [
+              "comparators": [
                 {
-                  "stepResult" : {
-                    "status" : "PASSED"
-                  },
-                  "filters" : [
+                  "stepResult": [
                     {
-                      "type" : "extract-element",
-                      "parameters" : {
-                        "elementId" : "date-panel"
+                      "status": "PASSED"
+                    }
+                  ],
+                  "filters": [
+                    {
+                      "type": "extract-element",
+                      "parameters": {
+                        "elementId": "date-panel"
                       }
                     }
                   ],
-                  "type" : "source",
-                  "parameters" : {
-                    "comparator" : "source"
+                  "type": "source",
+                  "parameters": {
+                    "comparator": "source"
                   }
                 }
               ],
-              "type" : "source"
+              "type": "source"
             }
           ]
         }

--- a/api/jobs-api/src/main/java/com/cognifide/aet/job/api/StepProperties.java
+++ b/api/jobs-api/src/main/java/com/cognifide/aet/job/api/StepProperties.java
@@ -16,8 +16,10 @@
 package com.cognifide.aet.job.api;
 
 
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.vs.DBKey;
 import com.google.common.base.MoreObjects;
+import java.util.Set;
 
 /**
  * POJO used to pass properties to Collectors/Comparators on worker.
@@ -30,12 +32,12 @@ public abstract class StepProperties implements DBKey {
 
   private final String project;
 
-  private final String patternId;
+  private final Set<Pattern> patternsIds;
 
-  public StepProperties(String company, String project, String patternId) {
+  public StepProperties(String company, String project, Set<Pattern> patternsIds) {
     this.company = company;
     this.project = project;
-    this.patternId = patternId;
+    this.patternsIds = patternsIds;
   }
 
   @Override
@@ -48,8 +50,8 @@ public abstract class StepProperties implements DBKey {
     return project;
   }
 
-  public String getPatternId() {
-    return patternId;
+  public Set<Pattern> getPatternsIds() {
+    return patternsIds;
   }
 
   @Override
@@ -57,7 +59,7 @@ public abstract class StepProperties implements DBKey {
     return MoreObjects.toStringHelper(this)
         .add("company", company)
         .add("project", project)
-        .add("patternId", patternId)
+        .add("patternsIds", patternsIds)
         .toString();
   }
 }

--- a/api/jobs-api/src/main/java/com/cognifide/aet/job/api/collector/CollectorProperties.java
+++ b/api/jobs-api/src/main/java/com/cognifide/aet/job/api/collector/CollectorProperties.java
@@ -15,7 +15,9 @@
  */
 package com.cognifide.aet.job.api.collector;
 
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.StepProperties;
+import java.util.Set;
 
 public class CollectorProperties extends StepProperties {
 
@@ -23,8 +25,8 @@ public class CollectorProperties extends StepProperties {
 
   private final String url;
 
-  public CollectorProperties(String url, String company, String project, String patternId) {
-    super(company, project, patternId);
+  public CollectorProperties(String url, String company, String project, Set<Pattern> patternIds) {
+    super(company, project, patternIds);
     this.url = url;
   }
 

--- a/api/jobs-api/src/main/java/com/cognifide/aet/job/api/comparator/ComparatorJob.java
+++ b/api/jobs-api/src/main/java/com/cognifide/aet/job/api/comparator/ComparatorJob.java
@@ -18,6 +18,7 @@ package com.cognifide.aet.job.api.comparator;
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
 import com.cognifide.aet.job.api.exceptions.ParametersException;
 import com.cognifide.aet.job.api.exceptions.ProcessingException;
+import java.util.List;
 import java.util.Map;
 
 public interface ComparatorJob {
@@ -27,7 +28,7 @@ public interface ComparatorJob {
    *
    * @return comparison result with details.
    */
-  ComparatorStepResult compare() throws ProcessingException;
+  List<ComparatorStepResult> compare() throws ProcessingException;
 
   /**
    * Setup all parameters necessary to perform comparison. Method is invoked before compare method.

--- a/api/jobs-api/src/main/java/com/cognifide/aet/job/api/comparator/ComparatorProperties.java
+++ b/api/jobs-api/src/main/java/com/cognifide/aet/job/api/comparator/ComparatorProperties.java
@@ -15,9 +15,11 @@
  */
 package com.cognifide.aet.job.api.comparator;
 
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.Payload;
 import com.cognifide.aet.job.api.StepProperties;
 import com.google.common.base.MoreObjects;
+import java.util.Set;
 
 public class ComparatorProperties extends StepProperties {
 
@@ -27,14 +29,14 @@ public class ComparatorProperties extends StepProperties {
 
   private final Payload payload;
 
-  public ComparatorProperties(String company, String project, String patternId,
+  public ComparatorProperties(String company, String project, Set<Pattern> patternsIds,
       String collectedId, Payload payload) {
-    super(company, project, patternId);
+    super(company, project, patternsIds);
     this.collectedId = collectedId;
     this.payload = payload;
   }
 
-  public ComparatorProperties(String company, String project, String patternId,
+  public ComparatorProperties(String company, String project, Set<Pattern> patternId,
       String collectedId) {
     this(company, project, patternId, collectedId, null);
   }
@@ -53,7 +55,7 @@ public class ComparatorProperties extends StepProperties {
         .add("collectedId", collectedId)
         .add("company", getCompany())
         .add("project", getProject())
-        .add("patternId", getPatternId())
+        .add("patternId", getPatternsIds())
         .toString();
   }
 }

--- a/client/client-scripts/aet.sh
+++ b/client/client-scripts/aet.sh
@@ -130,12 +130,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         -c | --correlationId )
             CORRELATION_ID=$2
-            CORRELATION_ID_BODY=" -F pattern=$CORRELATION_ID"
+            CORRELATION_ID_BODY="$CORRELATION_ID_BODY -F pattern=$CORRELATION_ID"
             shift 2
             ;;
         -p | --patternSuite )
             PATTERN_SUITE=$2
-            PATTERN_SUITE_BODY=" -F patternSuite=$PATTERN_SUITE"
+            PATTERN_SUITE_BODY="$PATTERN_SUITE_BODY -F patternSuite=$PATTERN_SUITE"
             shift 2
             ;;
         -v | --verbose )

--- a/core/cleaner/src/main/java/com/cognifide/aet/cleaner/processors/GetMetadataArtifactsProcessor.java
+++ b/core/cleaner/src/main/java/com/cognifide/aet/cleaner/processors/GetMetadataArtifactsProcessor.java
@@ -23,11 +23,11 @@ import com.cognifide.aet.communication.api.metadata.CollectorStepResult;
 import com.cognifide.aet.communication.api.metadata.Comparator;
 import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.Step;
+import com.cognifide.aet.communication.api.metadata.StepResult;
 import com.cognifide.aet.communication.api.metadata.Test;
 import com.cognifide.aet.communication.api.metadata.Url;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -49,16 +49,20 @@ public class GetMetadataArtifactsProcessor implements Processor {
   private static final Predicate<Comparator> STEP_RESULTS_WITH_ARTIFACT_ID = new Predicate<Comparator>() {
     @Override
     public boolean apply(Comparator comparator) {
-      return comparator.getStepResult() != null && StringUtils
-          .isNotBlank(comparator.getStepResult().getArtifactId());
+      return comparator.getStepResults() != null
+          && !comparator.getStepResults().isEmpty()
+          && comparator.getStepResults().stream()
+          .anyMatch(result -> StringUtils.isNotBlank(result.getArtifactId()));
     }
   };
 
-  private static final Function<Comparator, String> COMPARATOR_TO_ARTIFACT_ID = new Function<Comparator, String>() {
+  private static final Function<Comparator, Set<String>> COMPARATOR_TO_ARTIFACT_ID = new Function<Comparator, Set<String>>() {
     @Nullable
     @Override
-    public String apply(Comparator comparator) {
-      return comparator.getStepResult().getArtifactId();
+    public Set<String> apply(Comparator comparator) {
+      return comparator.getStepResults().stream()
+          .map(StepResult::getArtifactId)
+          .collect(Collectors.toSet());
     }
   };
 
@@ -120,10 +124,11 @@ public class GetMetadataArtifactsProcessor implements Processor {
   private Set<String> traverseComparators(Step step) {
     Set<String> stepArtifacts = Collections.emptySet();
     if (step.getComparators() != null) {
-      stepArtifacts = FluentIterable.from(step.getComparators())
+      stepArtifacts = step.getComparators().stream()
           .filter(STEP_RESULTS_WITH_ARTIFACT_ID)
-          .transform(COMPARATOR_TO_ARTIFACT_ID)
-          .toSet();
+          .flatMap(comparator -> comparator.getStepResults().stream()
+              .map(StepResult::getArtifactId))
+          .collect(Collectors.toSet());
     }
     return stepArtifacts;
   }

--- a/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/ComparatorDeserializer.java
+++ b/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/ComparatorDeserializer.java
@@ -1,0 +1,43 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.vs.metadata;
+
+import com.cognifide.aet.communication.api.metadata.Comparator;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class ComparatorDeserializer extends CompatibilityDeserializer<Comparator> {
+
+  private static final String RESULT_FIELD = "stepResult";
+
+  private static final String RESULTS_COLLECTION_FIELD = "stepResults";
+
+  @Override
+  protected void deserializeIncompatible(JsonObject comparatorObject,
+      JsonElement comparatorResultElement) {
+    JsonArray resultsArray = new JsonArray();
+    resultsArray.add(comparatorResultElement);
+    comparatorObject.add(RESULTS_COLLECTION_FIELD, resultsArray);
+
+    comparatorObject.remove(RESULT_FIELD);
+  }
+
+  @Override
+  protected String getPropertyFieldName() {
+    return RESULT_FIELD;
+  }
+}

--- a/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/CompatibilityDeserializer.java
+++ b/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/CompatibilityDeserializer.java
@@ -1,0 +1,68 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.vs.metadata;
+
+import static com.cognifide.aet.vs.metadata.DocumentConverter.DESERIALIZERS;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+public abstract class CompatibilityDeserializer<T> implements JsonDeserializer<T> {
+
+  @Override
+  public T deserialize(JsonElement jsonElement, Type type,
+      JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+
+    JsonObject stepObject = jsonElement.getAsJsonObject();
+    JsonElement element = stepObject.get(getPropertyFieldName());
+
+    if (element != null) {
+      deserializeIncompatible(stepObject, element);
+    }
+
+    return continueMapping(jsonElement, type);
+  }
+
+  private T continueMapping(JsonElement jsonElement, Type type) {
+    HashMap<Class, JsonDeserializer> deserializers = new HashMap<>(DESERIALIZERS);
+
+    removeCurrentDeserializer(type, deserializers);
+
+    GsonBuilder builder = new GsonBuilder();
+    deserializers.forEach(builder::registerTypeAdapter);
+    return builder.create().fromJson(jsonElement, type);
+
+  }
+
+  private void removeCurrentDeserializer(Type type,
+      HashMap<Class, JsonDeserializer> deserializers) {
+    try {
+      deserializers.remove(Class.forName(type.getTypeName()));
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+    }
+  }
+
+  protected abstract String getPropertyFieldName();
+
+  protected abstract void deserializeIncompatible(JsonObject object, JsonElement element);
+}

--- a/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/DocumentConverter.java
+++ b/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/DocumentConverter.java
@@ -15,18 +15,34 @@
  */
 package com.cognifide.aet.vs.metadata;
 
+import com.cognifide.aet.communication.api.metadata.Comparator;
+import com.cognifide.aet.communication.api.metadata.Step;
 import com.cognifide.aet.communication.api.metadata.Suite;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
 import org.bson.Document;
 
 class DocumentConverter {
 
-  private static final Gson GSON_FOR_MONGO_JSON = new GsonBuilder()
-      .registerTypeAdapter(Suite.Timestamp.class, new TimestampDeserializer())
-      .create();
+  private static final Gson GSON_FOR_MONGO_JSON;
+
+  static final Map<Class, JsonDeserializer> DESERIALIZERS = new HashMap<>();
+
+  static {
+    DESERIALIZERS.put(Suite.Timestamp.class, new TimestampDeserializer());
+    DESERIALIZERS.put(Step.class, new StepDeserializer());
+    DESERIALIZERS.put(Comparator.class, new ComparatorDeserializer());
+
+    GsonBuilder builder = new GsonBuilder();
+    DESERIALIZERS.forEach(builder::registerTypeAdapter);
+
+    GSON_FOR_MONGO_JSON = builder.create();
+  }
 
   private static final Type SUITE_TYPE = new TypeToken<Suite>() {
   }.getType();

--- a/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/StepDeserializer.java
+++ b/core/datastorage/src/main/java/com/cognifide/aet/vs/metadata/StepDeserializer.java
@@ -1,0 +1,47 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.vs.metadata;
+
+import com.cognifide.aet.communication.api.metadata.Step;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public class StepDeserializer extends CompatibilityDeserializer<Step> {
+
+  private static final String PATTERN_FIELD = "pattern";
+
+  private static final String PATTERNS_COLLECTION_FIELD = "patterns";
+
+  @Override
+  protected void deserializeIncompatible(JsonObject stepObject, JsonElement patternElement) {
+    String pattern = patternElement.getAsString();
+
+    JsonObject patternObject = new JsonObject();
+    patternObject.addProperty(PATTERN_FIELD, pattern);
+
+    JsonArray patternsArray = new JsonArray();
+    patternsArray.add(patternObject);
+    stepObject.add(PATTERNS_COLLECTION_FIELD, patternsArray);
+
+    stepObject.remove(PATTERN_FIELD);
+  }
+
+  @Override
+  protected String getPropertyFieldName() {
+    return PATTERN_FIELD;
+  }
+}

--- a/core/datastorage/src/test/java/com/cognifide/aet/vs/metadata/DocumentConverterTest.java
+++ b/core/datastorage/src/test/java/com/cognifide/aet/vs/metadata/DocumentConverterTest.java
@@ -1,0 +1,83 @@
+/**
+ * AET
+ *
+ * Copyright (C) 2013 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.cognifide.aet.vs.metadata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult.Status;
+import com.cognifide.aet.communication.api.metadata.Pattern;
+import com.cognifide.aet.communication.api.metadata.Suite;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.IOUtils;
+import org.bson.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class DocumentConverterTest {
+
+  private static final String PATTERN = "56f3b0a978139e1e6dabcd0e";
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"conversion/oldStructureSuite.json"}, {"conversion/currentStructureSuite.json"}
+    });
+  }
+
+  private String suiteReference;
+
+  public DocumentConverterTest(String suiteReference) {
+    this.suiteReference = suiteReference;
+  }
+
+  @Test
+  public void whenConvertingOldAndNewStructureSuite_shouldBeBackwardsCompatible()
+      throws IOException {
+    // given
+    String json = readSuite(suiteReference);
+    Document oldSuite = Document.parse(json);
+
+    // when
+    Suite suite = new DocumentConverter(oldSuite).toSuite();
+
+    Set<Pattern> patterns =
+        suite.getTests().get(0).getUrls().iterator().next().getSteps().get(0).getPatterns();
+    List<ComparatorStepResult> stepResults = suite.getTests().get(0).getUrls().iterator().next()
+        .getSteps().get(0).getComparators().iterator().next().getStepResults();
+
+    // then
+    assertThat(patterns, hasSize(1));
+    assertThat(patterns.iterator().next().getPattern(), equalTo(PATTERN));
+
+    assertThat(stepResults, hasSize(1));
+    assertThat(stepResults.get(0).getStatus(), equalTo(Status.PASSED));
+  }
+
+  private String readSuite(String resource) throws IOException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    return IOUtils.toString(classLoader.getResourceAsStream(resource));
+  }
+}

--- a/core/datastorage/src/test/resources/conversion/currentStructureSuite.json
+++ b/core/datastorage/src/test/resources/conversion/currentStructureSuite.json
@@ -1,0 +1,59 @@
+{
+  "correlationId": "unittest-project-0",
+  "company": "unittest",
+  "project": "project",
+  "name": "unitTestingSuite",
+  "version": 1,
+  "tests": [
+    {
+      "name": "test-one",
+      "comment": "test level comment",
+      "urls": [
+        {
+          "name": "/our-company",
+          "url": "/our-company",
+          "canonicalUrl": "/our-company",
+          "domain": "https://cognifide.com",
+          "comment": "url level comment",
+          "steps": [
+            {
+              "index": 0,
+              "name": "source",
+              "patterns": [
+                {
+                  "pattern": "56f3b0a978139e1e6dabcd0e"
+                }
+              ],
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56f3b0a978139e1e6dabcd0e"
+              },
+              "comparators": [
+                {
+                  "stepResults": [
+                    {
+                      "status": "PASSED"
+                    }
+                  ],
+                  "filters": [
+                    {
+                      "type": "extract-element",
+                      "parameters": {
+                        "elementId": "date-panel"
+                      }
+                    }
+                  ],
+                  "type": "source",
+                  "parameters": {
+                    "comparator": "source"
+                  }
+                }
+              ],
+              "type": "source"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/datastorage/src/test/resources/conversion/oldStructureSuite.json
+++ b/core/datastorage/src/test/resources/conversion/oldStructureSuite.json
@@ -1,0 +1,53 @@
+{
+  "correlationId": "unittest-project-0",
+  "company": "unittest",
+  "project": "project",
+  "name": "unitTestingSuite",
+  "version": 1,
+  "tests": [
+    {
+      "name": "test-one",
+      "comment": "test level comment",
+      "urls": [
+        {
+          "name": "/our-company",
+          "url": "/our-company",
+          "canonicalUrl": "/our-company",
+          "domain": "https://cognifide.com",
+          "comment": "url level comment",
+          "steps": [
+            {
+              "index": 0,
+              "name": "source",
+              "pattern": "56f3b0a978139e1e6dabcd0e",
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56f3b0a978139e1e6dabcd0e"
+              },
+              "comparators": [
+                {
+                  "stepResult": {
+                    "status": "PASSED"
+                  },
+                  "filters": [
+                    {
+                      "type": "extract-element",
+                      "parameters": {
+                        "elementId": "date-panel"
+                      }
+                    }
+                  ],
+                  "type": "source",
+                  "parameters": {
+                    "comparator": "source"
+                  }
+                }
+              ],
+              "type": "source"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
@@ -16,6 +16,7 @@
 package com.cognifide.aet.job.common.collectors.screen;
 
 import com.cognifide.aet.communication.api.metadata.CollectorStepResult;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.Payload;
 import com.cognifide.aet.communication.api.metadata.exclude.ExcludedElement;
 import com.cognifide.aet.communication.api.metadata.exclude.LayoutExclude;
@@ -85,8 +86,9 @@ public class ScreenCollector extends WebElementsLocatorParams implements Collect
     byte[] screenshot = takeScreenshot();
 
     CollectorStepResult stepResult;
-    if (isPatternAndResultMD5Identical(screenshot)) {
-      stepResult = CollectorStepResult.newResultThatDuplicatesPattern(properties.getPatternId());
+    if (isPatternsAndResultMD5Identical(screenshot)) {
+      String firstMatchingPattern = properties.getPatternsIds().iterator().next().getPattern();
+      stepResult = CollectorStepResult.newResultThatDuplicatesPattern(firstMatchingPattern);
     } else {
       try (final InputStream screenshotStream = new ByteArrayInputStream(screenshot)) {
         String resultId = artifactsDAO.saveArtifact(properties, screenshotStream, CONTENT_TYPE);
@@ -103,15 +105,22 @@ public class ScreenCollector extends WebElementsLocatorParams implements Collect
     return stepResult;
   }
 
-  private boolean isPatternAndResultMD5Identical(byte[] screenshot) {
-    if (properties.getPatternId() != null) {
-      final String screenshotMD5 = DigestUtils.md5Hex(screenshot);
-      final String patternMD5 = artifactsDAO
-          .getArtifactMD5(properties, properties.getPatternId());
-      return StringUtils.equalsIgnoreCase(patternMD5, screenshotMD5);
-    } else {
+  private boolean isPatternsAndResultMD5Identical(byte[] screenshot) {
+    if (properties.getPatternsIds() == null || properties.getPatternsIds().isEmpty()) {
       return false;
     }
+
+    return properties.getPatternsIds().stream()
+        .allMatch(pattern -> {
+          if (properties.getPatternsIds() != null && !properties.getPatternsIds().isEmpty()) {
+            final String screenshotMD5 = DigestUtils.md5Hex(screenshot);
+            final String patternMD5 = artifactsDAO
+                .getArtifactMD5(properties, pattern.getPattern());
+            return StringUtils.equalsIgnoreCase(patternMD5, screenshotMD5);
+          } else {
+            return false;
+          }
+        });
   }
 
   private CollectorStepResult getResultWithExcludeSelectors(String resultId) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollector.java
@@ -106,21 +106,20 @@ public class ScreenCollector extends WebElementsLocatorParams implements Collect
   }
 
   private boolean isPatternsAndResultMD5Identical(byte[] screenshot) {
-    if (properties.getPatternsIds() == null || properties.getPatternsIds().isEmpty()) {
-      return false;
-    }
+    final boolean isCollectedIdentical;
 
-    return properties.getPatternsIds().stream()
-        .allMatch(pattern -> {
-          if (properties.getPatternsIds() != null && !properties.getPatternsIds().isEmpty()) {
+    if (properties.getPatternsIds() == null || properties.getPatternsIds().isEmpty()) {
+      isCollectedIdentical = false;
+    } else {
+      isCollectedIdentical = properties.getPatternsIds().stream()
+          .allMatch(pattern -> {
             final String screenshotMD5 = DigestUtils.md5Hex(screenshot);
             final String patternMD5 = artifactsDAO
                 .getArtifactMD5(properties, pattern.getPattern());
             return StringUtils.equalsIgnoreCase(patternMD5, screenshotMD5);
-          } else {
-            return false;
-          }
-        });
+          });
+    }
+    return isCollectedIdentical;
   }
 
   private CollectorStepResult getResultWithExcludeSelectors(String resultId) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/accessibility/AccessibilityComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/accessibility/AccessibilityComparator.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -66,7 +67,7 @@ public class AccessibilityComparator implements ComparatorJob {
 
   @Override
   @SuppressWarnings("unchecked")
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
     final ComparatorStepResult result;
     try {
       List<AccessibilityIssue> issues = artifactsDAO.getJsonFormatArtifact(properties,
@@ -95,7 +96,7 @@ public class AccessibilityComparator implements ComparatorJob {
     } catch (Exception e) {
       throw new ProcessingException(e.getMessage(), e);
     }
-    return result;
+    return Collections.singletonList(result);
   }
 
   private ComparatorStepResult.Status getStatus(AccessibilityReport report) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparator.java
@@ -83,7 +83,7 @@ public class CookieComparator implements ComparatorJob {
   }
 
   @SuppressWarnings("unchecked")
-  private ComparatorStepResult compareCookies(Set<Cookie> cookies, Pattern pattern)
+  private ComparatorStepResult compare(Set<Cookie> cookies, Pattern pattern)
       throws IOException {
     final Set<Cookie> cookiesPattern = artifactsDAO
         .getJsonFormatArtifact(properties, pattern.getPattern(), COOKIES_SET_TYPE);
@@ -106,9 +106,9 @@ public class CookieComparator implements ComparatorJob {
 
     final String artifactId = artifactsDAO.saveArtifactInJsonFormat(properties, result);
 
-    ComparatorStepResult stepResult = new ComparatorStepResult(artifactId,
-        compareResult ? Status.PASSED : Status.FAILED,
-        !compareResult);
+    ComparatorStepResult stepResult = new ComparatorStepResult(artifactId, pattern,
+        compareResult ? Status.PASSED : Status.FAILED, !compareResult);
+
     stepResult.addData("compareAction", compareAction.name());
     return stepResult;
   }
@@ -154,7 +154,7 @@ public class CookieComparator implements ComparatorJob {
           result = Collections.singletonList(testCookie(cookies));
           break;
         case COMPARE:
-          result = compareCookies(cookies);
+          result = compare(cookies);
           break;
         case LIST:
         default:
@@ -167,10 +167,10 @@ public class CookieComparator implements ComparatorJob {
     return result;
   }
 
-  private List<ComparatorStepResult> compareCookies(Set<Cookie> cookies) throws IOException {
+  private List<ComparatorStepResult> compare(Set<Cookie> cookies) throws IOException {
     List<ComparatorStepResult> results = new ArrayList<>();
     for (Pattern pattern : properties.getPatternsIds()) {
-      results.add(compareCookies(cookies, pattern));
+      results.add(compare(cookies, pattern));
     }
     return results;
   }

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparator.java
@@ -16,6 +16,8 @@
 package com.cognifide.aet.job.common.comparators.cookie;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult.Status;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.comparator.ComparatorJob;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.api.exceptions.ParametersException;
@@ -27,7 +29,9 @@ import com.google.common.collect.Sets;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.openqa.selenium.Cookie;
@@ -79,10 +83,10 @@ public class CookieComparator implements ComparatorJob {
   }
 
   @SuppressWarnings("unchecked")
-  private ComparatorStepResult compareCookies(Set<Cookie> cookies) throws IOException {
+  private ComparatorStepResult compareCookies(Set<Cookie> cookies, Pattern pattern)
+      throws IOException {
     final Set<Cookie> cookiesPattern = artifactsDAO
-        .getJsonFormatArtifact(properties, properties.getPatternId(),
-            COOKIES_SET_TYPE);
+        .getJsonFormatArtifact(properties, pattern.getPattern(), COOKIES_SET_TYPE);
 
     final Set<String> collectedCookiesNames = FluentIterable.from(cookies)
         .transform(COOKIE_STRING_FUNCTION).toSet();
@@ -101,9 +105,12 @@ public class CookieComparator implements ComparatorJob {
         additionalCookies, foundCookies);
 
     final String artifactId = artifactsDAO.saveArtifactInJsonFormat(properties, result);
-    return new ComparatorStepResult(artifactId,
-        compareResult ? ComparatorStepResult.Status.PASSED : ComparatorStepResult.Status.FAILED,
+
+    ComparatorStepResult stepResult = new ComparatorStepResult(artifactId,
+        compareResult ? Status.PASSED : Status.FAILED,
         !compareResult);
+    stepResult.addData("compareAction", compareAction.name());
+    return stepResult;
   }
 
   private ComparatorStepResult testCookie(Set<Cookie> cookies) {
@@ -118,41 +125,54 @@ public class CookieComparator implements ComparatorJob {
     CookieTestComparatorResult result = new CookieTestComparatorResult(compareAction, cookies, name,
         value);
     final String artifactId = artifactsDAO.saveArtifactInJsonFormat(properties, result);
-    return new ComparatorStepResult(artifactId,
-        testResult ? ComparatorStepResult.Status.PASSED : ComparatorStepResult.Status.FAILED);
+    ComparatorStepResult stepResult = new ComparatorStepResult(artifactId,
+        testResult ? Status.PASSED : Status.FAILED);
+
+    stepResult.addData("compareAction", compareAction.name());
+
+    return stepResult;
   }
 
   private ComparatorStepResult listCookies(Set<Cookie> cookies) {
     CookieComparatorResult result = new CookieComparatorResult(compareAction, cookies);
     final String artifactId = artifactsDAO.saveArtifactInJsonFormat(properties, result);
-    return new ComparatorStepResult(artifactId, ComparatorStepResult.Status.PASSED);
+    ComparatorStepResult stepResult = new ComparatorStepResult(artifactId, Status.PASSED);
+    stepResult.addData("compareAction", compareAction.name());
+    return stepResult;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public ComparatorStepResult compare() throws ProcessingException {
-    ComparatorStepResult result;
+  public List<ComparatorStepResult> compare() throws ProcessingException {
+    List<ComparatorStepResult> result;
     try {
       final Set<Cookie> cookies = artifactsDAO
           .getJsonFormatArtifact(properties, properties.getCollectedId(),
               COOKIES_SET_TYPE);
       switch (compareAction) {
         case TEST:
-          result = testCookie(cookies);
+          result = Collections.singletonList(testCookie(cookies));
           break;
         case COMPARE:
           result = compareCookies(cookies);
           break;
         case LIST:
         default:
-          result = listCookies(cookies);
+          result = Collections.singletonList(listCookies(cookies));
           break;
       }
-      result.addData("compareAction", compareAction.name());
     } catch (IOException e) {
       throw new ProcessingException("Error while obtaining cookies from " + properties, e);
     }
     return result;
+  }
+
+  private List<ComparatorStepResult> compareCookies(Set<Cookie> cookies) throws IOException {
+    List<ComparatorStepResult> results = new ArrayList<>();
+    for (Pattern pattern : properties.getPatternsIds()) {
+      results.add(compareCookies(cookies, pattern));
+    }
+    return results;
   }
 
   @Override

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/jserrors/JsErrorsComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/jserrors/JsErrorsComparator.java
@@ -26,6 +26,7 @@ import com.cognifide.aet.vs.ArtifactsDAO;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,7 +58,7 @@ public class JsErrorsComparator implements ComparatorJob {
 
   @Override
   @SuppressWarnings("unchecked")
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
     final ComparatorStepResult result;
     LOGGER.info("Starting JS Error Comparison with parameters {}.", comparatorProperties);
     try {
@@ -80,7 +81,7 @@ public class JsErrorsComparator implements ComparatorJob {
     } catch (Exception e) {
       throw new ProcessingException("Failed to obtain Js Errors Collection Result!", e);
     }
-    return result;
+    return Collections.singletonList(result);
   }
 
   private boolean noErrorsOrIgnoredOnly(Set<JsErrorLog> jsErrorLogs) {

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparator.java
@@ -155,9 +155,10 @@ public class LayoutComparator implements ComparatorJob {
         result = getPassedStepResult(pattern);
       } else if (hasMaskThresholdWithAcceptableDifference(imageComparisonResult)
           || isMaskWithoutDifference(imageComparisonResult)) {
-        result = new ComparatorStepResult(maskArtifactId, Status.CONDITIONALLY_PASSED, true);
+        result = new ComparatorStepResult(maskArtifactId, pattern, Status.CONDITIONALLY_PASSED,
+            true);
       } else {
-        result = new ComparatorStepResult(maskArtifactId, Status.FAILED, true);
+        result = new ComparatorStepResult(maskArtifactId, pattern, Status.FAILED, true);
       }
 
       if (!CollectionUtils.isEmpty(notFoundExcludeElements)) {
@@ -234,10 +235,7 @@ public class LayoutComparator implements ComparatorJob {
   }
 
   private ComparatorStepResult getPassedStepResult(Pattern pattern) {
-    ComparatorStepResult result = new ComparatorStepResult(null, ComparatorStepResult.Status.PASSED,
-        false);
-    addTimestampToResult(result, pattern);
-    return result;
+    return new ComparatorStepResult(null, Status.PASSED);
   }
 
   @Override

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparator.java
@@ -17,6 +17,7 @@ package com.cognifide.aet.job.common.comparators.layout;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult.Status;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.Payload;
 import com.cognifide.aet.communication.api.metadata.exclude.ExcludedElement;
 import com.cognifide.aet.job.api.ParametersValidator;
@@ -34,6 +35,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
@@ -86,16 +88,26 @@ public class LayoutComparator implements ComparatorJob {
   }
 
   @Override
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
+    List<ComparatorStepResult> results = new ArrayList<>();
+
+    for (Pattern pattern : properties.getPatternsIds()) {
+      results.add(compareToPattern(pattern));
+    }
+
+    return results;
+  }
+
+  private ComparatorStepResult compareToPattern(Pattern pattern) throws ProcessingException {
     final ComparatorStepResult stepResult;
     ImageComparisonResult imageComparisonResult;
-    if (areInputsIdentical(artifactsDAO, properties)) {
-      stepResult = getPassedStepResult();
+    if (areInputsIdentical(artifactsDAO, properties, pattern)) {
+      stepResult = getPassedStepResult(pattern);
     } else {
       try (InputStream collectedArtifact = artifactsDAO
           .getArtifact(properties, properties.getCollectedId()).getArtifactStream();
           InputStream patternArtifact = artifactsDAO
-              .getArtifact(properties, properties.getPatternId()).getArtifactStream()) {
+              .getArtifact(properties, pattern.getPattern()).getArtifactStream()) {
 
         BufferedImage patternImg = ImageIO.read(patternArtifact);
         BufferedImage collectedImg = ImageIO.read(collectedArtifact);
@@ -113,7 +125,7 @@ public class LayoutComparator implements ComparatorJob {
             });
 
         imageComparisonResult = ImageComparison.compare(patternImg, collectedImg);
-        stepResult = saveArtifacts(imageComparisonResult);
+        stepResult = saveArtifacts(imageComparisonResult, pattern);
       } catch (IOException e) {
         throw new ProcessingException("Error while obtaining artifacts!", e);
       }
@@ -122,13 +134,15 @@ public class LayoutComparator implements ComparatorJob {
     return stepResult;
   }
 
-  private boolean areInputsIdentical(ArtifactsDAO artifactsDAO, ComparatorProperties properties) {
+  private boolean areInputsIdentical(ArtifactsDAO artifactsDAO, ComparatorProperties properties,
+      Pattern pattern) {
     String collectedMD5 = artifactsDAO.getArtifactMD5(properties, properties.getCollectedId());
-    String patternMD5 = artifactsDAO.getArtifactMD5(properties, properties.getPatternId());
+    String patternMD5 = artifactsDAO.getArtifactMD5(properties, pattern.getPattern());
     return StringUtils.equalsIgnoreCase(collectedMD5, patternMD5);
   }
 
-  private ComparatorStepResult saveArtifacts(ImageComparisonResult imageComparisonResult)
+  private ComparatorStepResult saveArtifacts(ImageComparisonResult imageComparisonResult,
+      Pattern pattern)
       throws ProcessingException {
     final ComparatorStepResult result;
     InputStream mask = null;
@@ -138,7 +152,7 @@ public class LayoutComparator implements ComparatorJob {
       String maskArtifactId = artifactsDAO.saveArtifact(properties, mask, CONTENT_TYPE);
 
       if (!excludeFunctionIsOn && isMaskWithoutDifference(imageComparisonResult)) {
-        result = getPassedStepResult();
+        result = getPassedStepResult(pattern);
       } else if (hasMaskThresholdWithAcceptableDifference(imageComparisonResult)
           || isMaskWithoutDifference(imageComparisonResult)) {
         result = new ComparatorStepResult(maskArtifactId, Status.CONDITIONALLY_PASSED, true);
@@ -153,7 +167,7 @@ public class LayoutComparator implements ComparatorJob {
       }
 
       addPixelDifferenceDataToResult(result, imageComparisonResult);
-      addTimestampToResult(result);
+      addTimestampToResult(result, pattern);
     } catch (Exception e) {
       throw new ProcessingException(e.getMessage(), e);
     } finally {
@@ -213,16 +227,16 @@ public class LayoutComparator implements ComparatorJob {
     result.addData("notFoundCssElements", notFoundCssElements);
   }
 
-  private void addTimestampToResult(ComparatorStepResult result) {
+  private void addTimestampToResult(ComparatorStepResult result, Pattern pattern) {
     result.addData("patternTimestamp", Long.toString(
-        artifactsDAO.getArtifactUploadDate(properties, properties.getPatternId()).getTime()));
+        artifactsDAO.getArtifactUploadDate(properties, pattern.getPattern()).getTime()));
     result.addData("collectTimestamp", Long.toString(System.currentTimeMillis()));
   }
 
-  private ComparatorStepResult getPassedStepResult() {
+  private ComparatorStepResult getPassedStepResult(Pattern pattern) {
     ComparatorStepResult result = new ComparatorStepResult(null, ComparatorStepResult.Status.PASSED,
         false);
-    addTimestampToResult(result);
+    addTimestampToResult(result, pattern);
     return result;
   }
 

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/permormance/clientside/ClientSidePerformanceComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/permormance/clientside/ClientSidePerformanceComparator.java
@@ -23,6 +23,8 @@ import com.cognifide.aet.job.api.exceptions.ProcessingException;
 import com.cognifide.aet.job.common.comparators.permormance.clientside.parser.ClientSidePerformanceComparatorResultData;
 import com.cognifide.aet.job.common.comparators.permormance.clientside.parser.ClientSidePerformanceParser;
 import com.cognifide.aet.vs.ArtifactsDAO;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class ClientSidePerformanceComparator implements ComparatorJob {
@@ -46,7 +48,7 @@ public class ClientSidePerformanceComparator implements ComparatorJob {
   }
 
   @Override
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
     final ComparatorStepResult result;
     try {
       String collectedData = artifactsDAO
@@ -61,7 +63,7 @@ public class ClientSidePerformanceComparator implements ComparatorJob {
     } catch (Exception e) {
       throw new ProcessingException(e.getMessage(), e);
     }
-    return result;
+    return Collections.singletonList(result);
   }
 
   @Override

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/source/SourceComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/source/SourceComparator.java
@@ -16,6 +16,7 @@
 package com.cognifide.aet.job.common.comparators.source;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.comparator.ComparatorJob;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.api.datafilter.DataFilterJob;
@@ -27,6 +28,7 @@ import com.cognifide.aet.job.common.comparators.source.visitors.ContentVisitor;
 import com.cognifide.aet.job.common.comparators.source.visitors.MarkupVisitor;
 import com.cognifide.aet.job.common.comparators.source.visitors.NodeTraversor;
 import com.cognifide.aet.vs.ArtifactsDAO;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -68,11 +70,21 @@ public class SourceComparator implements ComparatorJob {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final ComparatorStepResult compare() throws ProcessingException {
+  public final List<ComparatorStepResult> compare() throws ProcessingException {
+    List<ComparatorStepResult> results = new ArrayList<>();
+
+    for (Pattern pattern : properties.getPatternsIds()) {
+      results.add(compare(pattern));
+    }
+
+    return results;
+  }
+
+  public final ComparatorStepResult compare(Pattern pattern) throws ProcessingException {
     final ComparatorStepResult result;
     try {
       String patternSource = formatCode(
-          artifactsDAO.getArtifactAsString(properties, properties.getPatternId()));
+          artifactsDAO.getArtifactAsString(properties, pattern.getPattern()));
       String dataSource = formatCode(
           artifactsDAO.getArtifactAsString(properties, properties.getCollectedId()));
 

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/source/SourceComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/source/SourceComparator.java
@@ -108,10 +108,10 @@ public class SourceComparator implements ComparatorJob {
         final List<ResultDelta> deltas = diffParser
             .generateDiffs(patternSource, dataSource, compareTrimmedLines);
         if (deltas.isEmpty()) {
-          result = new ComparatorStepResult(null, ComparatorStepResult.Status.PASSED, false);
+          result = new ComparatorStepResult(null, ComparatorStepResult.Status.PASSED);
         } else {
           result = new ComparatorStepResult(artifactsDAO.saveArtifactInJsonFormat(properties,
-              Collections.singletonMap("differences", deltas)),
+              Collections.singletonMap("differences", deltas)), pattern,
               ComparatorStepResult.Status.FAILED, true);
           result.addData("formattedPattern", artifactsDAO.saveArtifact(properties, patternSource));
           result.addData("formattedSource", artifactsDAO.saveArtifact(properties, dataSource));

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/statuscodes/StatusCodesComparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/statuscodes/StatusCodesComparator.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ public class StatusCodesComparator implements ComparatorJob {
 
   @Override
   @SuppressWarnings("unchecked")
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
     final ComparatorStepResult result;
     LOGGER.info("Starting comparison phase for  status codes for Company: {} Project: {}",
         properties.getCompany(), properties.getProject());
@@ -128,7 +129,7 @@ public class StatusCodesComparator implements ComparatorJob {
     } catch (Exception e) {
       throw new ProcessingException(e.getMessage(), e);
     }
-    return result;
+    return Collections.singletonList(result);
   }
 
   @Override

--- a/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/W3cHtml5Comparator.java
+++ b/core/jobs/src/main/java/com/cognifide/aet/job/common/comparators/w3chtml5/W3cHtml5Comparator.java
@@ -24,6 +24,7 @@ import com.cognifide.aet.job.common.comparators.w3chtml5.parser.W3cHtml5Validati
 import com.cognifide.aet.job.common.comparators.w3chtml5.wrapper.NuValidatorWrapper;
 import com.cognifide.aet.vs.ArtifactsDAO;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
@@ -57,13 +58,13 @@ class W3cHtml5Comparator extends W3cHtml5ComparatorJob {
   }
 
   @Override
-  public ComparatorStepResult compare() throws ProcessingException {
+  public List<ComparatorStepResult> compare() throws ProcessingException {
     ComparatorStepResult comparatorStepResult;
     InputStream sourceStream = null;
     try {
       LOGGER.info("Checking w3c for artifact {} in {} {} using validator: {}.",
           properties.getCompany(),
-          properties.getProject(), properties.getPatternId(), properties);
+          properties.getProject(), properties.getPatternsIds(), properties);
       sourceStream = artifactsDAO.getArtifact(properties, properties.getCollectedId())
           .getArtifactStream();
 
@@ -76,7 +77,7 @@ class W3cHtml5Comparator extends W3cHtml5ComparatorJob {
     } finally {
       IOUtils.closeQuietly(sourceStream);
     }
-    return comparatorStepResult;
+    return Collections.singletonList(comparatorStepResult);
   }
 
   @Override

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollectorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollectorTest.java
@@ -16,20 +16,24 @@
 package com.cognifide.aet.job.common.collectors.screen;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.cognifide.aet.communication.api.metadata.CollectorStepResult;
+import com.cognifide.aet.communication.api.metadata.CollectorStepResult.Status;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.exclude.LayoutExclude;
 import com.cognifide.aet.job.api.collector.CollectorProperties;
 import com.cognifide.aet.job.api.exceptions.ParametersException;
+import com.cognifide.aet.job.api.exceptions.ProcessingException;
 import com.cognifide.aet.vs.ArtifactsDAO;
-import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,6 +50,12 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 @RunWith(MockitoJUnitRunner.class)
 public class ScreenCollectorTest {
 
+  private static final String PATTERN_ARTIFACT_ID = "foo";
+
+  private static final byte[] SCREENSHOT = {1, 2, 3, 4};
+
+  private static final String PATTERN_MD5 = DigestUtils.md5Hex(SCREENSHOT);
+
   private static final String SELECTOR_1 = ".dynamic1";
 
   private static final String SELECTOR_2 = ".dynamic2";
@@ -57,28 +67,41 @@ public class ScreenCollectorTest {
   private WebElement webElement2;
 
   @Mock
+  private ArtifactsDAO artifactsDAO;
+
+  @Mock
   private RemoteWebDriver webDriver;
 
   @Mock
   private CollectorProperties collectorProperties;
 
-  @Mock
-  private ArtifactsDAO artifactsDAO;
-
   @InjectMocks
   private ScreenCollector screenCollector;
 
-  private byte[] screenshot = {1, 2};
 
   @Before
   public void setup() throws Exception {
-    when(collectorProperties.getPatternId()).thenReturn(null);
-    when(webDriver.getScreenshotAs(OutputType.BYTES)).thenReturn(screenshot);
+    when(collectorProperties.getPatternsIds()).thenReturn(Collections.emptySet());
+    when(webDriver.getScreenshotAs(OutputType.BYTES)).thenReturn(SCREENSHOT);
 
     when(webElement1.getLocation().moveBy(anyInt(), anyInt())).thenReturn(new Point(0, 0));
     when(webElement2.getLocation().moveBy(anyInt(), anyInt())).thenReturn(new Point(0, 0));
 
     setExcludeElementsParam(String.format("%s,%s", SELECTOR_1, SELECTOR_2));
+  }
+
+  @Test
+  public void shouldReturnDuplicatesPatternResult_WhenScreenshotAndAllPatternsMd5Identical()
+      throws ProcessingException {
+    when(webDriver.getScreenshotAs(any())).thenReturn(SCREENSHOT);
+    when(collectorProperties.getPatternsIds()).thenReturn(
+        Collections.singleton(new Pattern(PATTERN_ARTIFACT_ID)));
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_ARTIFACT_ID))).thenReturn(PATTERN_MD5);
+
+    CollectorStepResult stepResult = screenCollector.collect();
+
+    assertEquals(Status.DUPLICATES_PATTERN, stepResult.getStatus());
+    assertEquals(PATTERN_ARTIFACT_ID, stepResult.getArtifactId());
   }
 
   @Test

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollectorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/collectors/screen/ScreenCollectorTest.java
@@ -95,7 +95,7 @@ public class ScreenCollectorTest {
       throws ProcessingException {
     when(webDriver.getScreenshotAs(any())).thenReturn(SCREENSHOT);
     when(collectorProperties.getPatternsIds()).thenReturn(
-        Collections.singleton(new Pattern(PATTERN_ARTIFACT_ID)));
+        Collections.singleton(new Pattern(PATTERN_ARTIFACT_ID, null)));
     when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_ARTIFACT_ID))).thenReturn(PATTERN_MD5);
 
     CollectorStepResult stepResult = screenCollector.collect();

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/AbstractComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/AbstractComparatorTest.java
@@ -19,6 +19,7 @@ import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.common.ArtifactDAOMock;
 import java.io.IOException;
+import java.util.List;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -33,7 +34,7 @@ public abstract class AbstractComparatorTest {
 
   protected static final String TEST_PROJECT = "aet";
 
-  protected ComparatorStepResult result;
+  protected List<ComparatorStepResult> result;
 
   protected String getExpectedString(String filename) throws IOException {
     return artifactDaoMock.getArtifactAsUTF8String(null, filename);

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/accessibility/AccessibilityComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/accessibility/AccessibilityComparatorTest.java
@@ -49,7 +49,8 @@ public class AccessibilityComparatorTest extends AbstractComparatorTest {
     accessibilityComparator.setParameters(ImmutableMap.of("report-level", "WARN"));
     result = accessibilityComparator.compare();
     assertEqualsToSavedArtifact("report-level-warn-result.json");
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -57,6 +58,6 @@ public class AccessibilityComparatorTest extends AbstractComparatorTest {
     accessibilityComparator.setParameters(ImmutableMap.of("report-level", "ERROR"));
     result = accessibilityComparator.compare();
     assertEqualsToSavedArtifact("report-level-error-result.json");
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparatorTest.java
@@ -18,10 +18,12 @@ package com.cognifide.aet.job.common.comparators.cookie;
 import static org.junit.Assert.assertEquals;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.common.ArtifactDAOMock;
 import com.cognifide.aet.job.common.comparators.AbstractComparatorTest;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +38,7 @@ public class CookieComparatorTest extends AbstractComparatorTest {
   public void setUp() throws Exception {
     artifactDaoMock = new ArtifactDAOMock(CookieComparator.class);
     comparatorProperties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        "pattern-result.json", "data-result.json");
+        Collections.singleton(new Pattern("pattern-result.json")), "data-result.json");
     tested = new CookieComparator(comparatorProperties, artifactDaoMock);
   }
 
@@ -46,7 +48,8 @@ public class CookieComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-list-result.json");
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -55,7 +58,8 @@ public class CookieComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-test-success-result.json");
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -64,19 +68,21 @@ public class CookieComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-test-failed-result.json");
-    assertEquals(result.getStatus(), ComparatorStepResult.Status.FAILED);
+    assertEquals(result.get(0).getStatus(), ComparatorStepResult.Status.FAILED);
+    assertEquals(1, result.size());
   }
 
   @Test
   public void testCompare_compareSuccess() throws Exception {
     comparatorProperties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        "identical-pattern-result.json", "data-result.json");
+        Collections.singleton(new Pattern("identical-pattern-result.json")), "data-result.json");
     tested = new CookieComparator(comparatorProperties, artifactDaoMock);
     tested.setParameters(ImmutableMap.of("action", "compare", "showMatched", "true"));
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-compare-success-result.json");
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -85,7 +91,8 @@ public class CookieComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-compare-failed-result.json");
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/cookie/CookieComparatorTest.java
@@ -38,7 +38,7 @@ public class CookieComparatorTest extends AbstractComparatorTest {
   public void setUp() throws Exception {
     artifactDaoMock = new ArtifactDAOMock(CookieComparator.class);
     comparatorProperties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        Collections.singleton(new Pattern("pattern-result.json")), "data-result.json");
+        Collections.singleton(new Pattern("pattern-result.json", null)), "data-result.json");
     tested = new CookieComparator(comparatorProperties, artifactDaoMock);
   }
 
@@ -75,7 +75,8 @@ public class CookieComparatorTest extends AbstractComparatorTest {
   @Test
   public void testCompare_compareSuccess() throws Exception {
     comparatorProperties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        Collections.singleton(new Pattern("identical-pattern-result.json")), "data-result.json");
+        Collections.singleton(new Pattern("identical-pattern-result.json", null)),
+        "data-result.json");
     tested = new CookieComparator(comparatorProperties, artifactDaoMock);
     tested.setParameters(ImmutableMap.of("action", "compare", "showMatched", "true"));
     result = tested.compare();

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/jserrors/JsErrorsComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/jserrors/JsErrorsComparatorTest.java
@@ -49,7 +49,8 @@ public class JsErrorsComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEqualsToSavedArtifact("expected-result.json");
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -61,6 +62,7 @@ public class JsErrorsComparatorTest extends AbstractComparatorTest {
     result = tested.compare();
 
     assertEquals(null, getActual());
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparatorTest.java
@@ -16,12 +16,33 @@
 package com.cognifide.aet.job.common.comparators.layout;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.ComparatorStepResult.Status;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
+import com.cognifide.aet.job.api.exceptions.ProcessingException;
 import com.cognifide.aet.job.common.comparators.layout.utils.ImageComparisonResult;
+import com.cognifide.aet.vs.Artifact;
 import com.cognifide.aet.vs.ArtifactsDAO;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import javax.imageio.ImageIO;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +51,16 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LayoutComparatorTest {
+
+  private static final Pattern PATTERN_1 = new Pattern("1");
+
+  private static final Pattern PATTERN_2 = new Pattern("2");
+
+  private static final String ARTIFACT_MD5_1 = "1";
+
+  private static final String ARTIFACT_MD5_2 = "2";
+
+  private static final String COLLECTED_ID = "3";
 
   @Mock
   private ComparatorProperties comparatorProperties;
@@ -46,6 +77,13 @@ public class LayoutComparatorTest {
   public void setUp() {
     //given
     this.layoutComparator = new LayoutComparator(this.comparatorProperties, this.artifactsDAO);
+
+    List<Pattern> patterns = Arrays.asList(PATTERN_1, PATTERN_2);
+    when(comparatorProperties.getPatternsIds()).thenReturn(new HashSet<>(patterns));
+    when(comparatorProperties.getCollectedId()).thenReturn(COLLECTED_ID);
+    when(comparatorProperties.getPayload()).thenReturn(null);
+
+    when(artifactsDAO.getArtifactUploadDate(any(), any())).thenReturn(new Date());
   }
 
   @Test
@@ -70,7 +108,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(null);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(false));
 
     //when
@@ -78,7 +117,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(12.566);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(false));
   }
 
@@ -92,7 +132,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(null);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(true));
 
     //when
@@ -100,7 +141,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(12.567);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(true));
   }
 
@@ -114,7 +156,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(30.0);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(false));
 
     //when
@@ -122,7 +165,8 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(12.566);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(false));
   }
 
@@ -136,8 +180,85 @@ public class LayoutComparatorTest {
     this.layoutComparator.setPercentageThreshold(12.567);
 
     //then
-    assertThat(this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
+    assertThat(
+        this.layoutComparator.hasMaskThresholdWithAcceptableDifference(imageComparisonResult),
         is(true));
   }
 
+  @Test
+  public void shouldReturnPassedComparatorResults_whenAllPatternsMatch()
+      throws ProcessingException {
+    //given
+    when(artifactsDAO.getArtifactMD5(any(), eq(COLLECTED_ID))).thenReturn(ARTIFACT_MD5_1);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_1.getPattern()))).thenReturn(ARTIFACT_MD5_1);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_2.getPattern()))).thenReturn(ARTIFACT_MD5_1);
+
+    //when
+    List<ComparatorStepResult> comparatorStepResults = this.layoutComparator.compare();
+
+    //then
+    comparatorStepResults.forEach(result -> assertThat(result.getStatus(), equalTo(Status.PASSED)));
+    assertThat(comparatorStepResults, hasSize(2));
+  }
+
+  @Test
+  public void shouldReturnMultipleFailedComparatorResults_whenAllPatternsDontMatch()
+      throws ProcessingException, IOException {
+    //given
+    when(artifactsDAO.getArtifactMD5(any(), eq(COLLECTED_ID))).thenReturn(ARTIFACT_MD5_1);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_1.getPattern()))).thenReturn(ARTIFACT_MD5_2);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_2.getPattern()))).thenReturn(ARTIFACT_MD5_2);
+
+    when(artifactsDAO.getArtifact(any(), eq(COLLECTED_ID)))
+        .thenReturn(getMockImageArtifact(Color.RED))
+        .thenReturn(getMockImageArtifact(Color.RED));
+    when(artifactsDAO.getArtifact(any(), eq(PATTERN_1.getPattern())))
+        .thenReturn(getMockImageArtifact(Color.BLACK));
+    when(artifactsDAO.getArtifact(any(), eq(PATTERN_2.getPattern())))
+        .thenReturn(getMockImageArtifact(Color.BLUE));
+
+    //when
+    List<ComparatorStepResult> comparatorStepResults = this.layoutComparator.compare();
+
+    //then
+    comparatorStepResults.forEach(result -> assertThat(result.getStatus(), equalTo(Status.FAILED)));
+    assertThat(comparatorStepResults, hasSize(2));
+  }
+
+  @Test
+  public void shouldReturnPassedAndFailedComparatorResults_whenSomePatternsMatch()
+      throws IOException, ProcessingException {
+    //given
+    when(artifactsDAO.getArtifactMD5(any(), eq(COLLECTED_ID))).thenReturn(ARTIFACT_MD5_1);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_1.getPattern()))).thenReturn(ARTIFACT_MD5_2);
+    when(artifactsDAO.getArtifactMD5(any(), eq(PATTERN_2.getPattern()))).thenReturn(ARTIFACT_MD5_2);
+
+    when(artifactsDAO.getArtifact(any(), eq(COLLECTED_ID)))
+        .thenReturn(getMockImageArtifact(Color.GREEN))
+        .thenReturn(getMockImageArtifact(Color.GREEN));
+    when(artifactsDAO.getArtifact(any(), eq(PATTERN_1.getPattern())))
+        .thenReturn(getMockImageArtifact(Color.GREEN));
+    when(artifactsDAO.getArtifact(any(), eq(PATTERN_2.getPattern())))
+        .thenReturn(getMockImageArtifact(Color.RED));
+
+    //when
+    List<ComparatorStepResult> comparatorStepResults = this.layoutComparator.compare();
+
+    //then
+    assertThat(comparatorStepResults.get(0).getStatus(), equalTo(Status.PASSED));
+    assertThat(comparatorStepResults.get(1).getStatus(), equalTo(Status.FAILED));
+    assertThat(comparatorStepResults, hasSize(2));
+  }
+
+  private Artifact getMockImageArtifact(Color seed) throws IOException {
+    BufferedImage bufferedImage = new BufferedImage(2, 2, 1);
+    bufferedImage.setRGB(0, 0, seed.getRGB());
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    ImageIO.write(bufferedImage, "jpg", os);
+    InputStream is = new ByteArrayInputStream(os.toByteArray());
+
+    os.flush();
+    return new Artifact(is, StringUtils.EMPTY);
+  }
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/layout/LayoutComparatorTest.java
@@ -52,9 +52,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class LayoutComparatorTest {
 
-  private static final Pattern PATTERN_1 = new Pattern("1");
+  private static final Pattern PATTERN_1 = new Pattern("1", null);
 
-  private static final Pattern PATTERN_2 = new Pattern("2");
+  private static final Pattern PATTERN_2 = new Pattern("2", null);
 
   private static final String ARTIFACT_MD5_1 = "1";
 

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
@@ -58,7 +58,7 @@ public class SourceComparatorTest extends AbstractComparatorTest {
       Map<String, String> comparatorParams)
       throws Exception {
     ComparatorProperties properties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        Collections.singleton(new Pattern(patternFilename)), dataFilename);
+        Collections.singleton(new Pattern(patternFilename, null)), dataFilename);
     tested = new SourceComparator(artifactDaoMock, properties, new DiffParser(),
         new ArrayList<DataFilterJob>());
     tested.setParameters(comparatorParams);

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/source/SourceComparatorTest.java
@@ -18,6 +18,7 @@ package com.cognifide.aet.job.common.comparators.source;
 import static org.junit.Assert.assertEquals;
 
 import com.cognifide.aet.communication.api.metadata.ComparatorStepResult;
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.job.api.datafilter.DataFilterJob;
 import com.cognifide.aet.job.common.ArtifactDAOMock;
@@ -25,7 +26,9 @@ import com.cognifide.aet.job.common.comparators.AbstractComparatorTest;
 import com.cognifide.aet.job.common.comparators.source.diff.DiffParser;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,11 +54,11 @@ public class SourceComparatorTest extends AbstractComparatorTest {
    * @return result of comparison
    * @throws Exception for incorrect parameters
    */
-  protected ComparatorStepResult compare(String patternFilename, String dataFilename,
+  protected List<ComparatorStepResult> compare(String patternFilename, String dataFilename,
       Map<String, String> comparatorParams)
       throws Exception {
     ComparatorProperties properties = new ComparatorProperties(TEST_COMPANY, TEST_PROJECT,
-        patternFilename, dataFilename);
+        Collections.singleton(new Pattern(patternFilename)), dataFilename);
     tested = new SourceComparator(artifactDaoMock, properties, new DiffParser(),
         new ArrayList<DataFilterJob>());
     tested.setParameters(comparatorParams);
@@ -66,7 +69,8 @@ public class SourceComparatorTest extends AbstractComparatorTest {
   public void testCompareOfValidInput() throws Exception {
     result = compare("pattern-source.html", "data-source.html", new HashMap<String, String>());
 
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
     assertEquals(null, getActual());
   }
 
@@ -75,7 +79,8 @@ public class SourceComparatorTest extends AbstractComparatorTest {
     result = compare("pattern-source.html", "data-invalid-source.html",
         new HashMap<String, String>());
 
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
+    assertEquals(1, result.size());
     assertEqualsToSavedArtifact("expected-invalid-result.json");
   }
 
@@ -83,7 +88,8 @@ public class SourceComparatorTest extends AbstractComparatorTest {
   public void testCompareMarkupWithDifferentText() throws Exception {
     result = compare("markup/pattern-source.html", "markup/data-source.html",
         ImmutableMap.of("compareType", "markup"));
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -91,7 +97,8 @@ public class SourceComparatorTest extends AbstractComparatorTest {
     result = compare("markup/pattern-source.html",
         "markup/data-source-with-different-attribute-value.html",
         ImmutableMap.of("compareType", "markup"));
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
+    assertEquals(1, result.size());
 
   }
 }

--- a/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/statuscodes/StatusCodesComparatorTest.java
+++ b/core/jobs/src/test/java/com/cognifide/aet/job/common/comparators/statuscodes/StatusCodesComparatorTest.java
@@ -84,7 +84,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested = createNewStatusCodesComparator("expected-data-200-result.json");
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -96,7 +97,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 
   @Test
@@ -109,7 +111,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -122,7 +125,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 
   @Test
@@ -136,7 +140,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -150,7 +155,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 
   @Test
@@ -164,7 +170,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
 
     params = ImmutableMap
         .of(PARAM_FILTER_CODES, FILTER_CODES_MULTIPLE,
@@ -172,7 +179,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
 
     params = ImmutableMap
         .of(PARAM_FILTER_CODES, FILTER_CODES_MULTIPLE,
@@ -180,7 +188,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 
   @Test
@@ -194,7 +203,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -208,7 +218,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested.setParameters(params);
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -216,7 +227,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested = createNewStatusCodesComparator("default-range-399-601-errors-result.json");
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.PASSED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.PASSED, result.get(0).getStatus());
   }
 
   @Test
@@ -224,7 +236,8 @@ public class StatusCodesComparatorTest extends AbstractComparatorTest {
     tested = createNewStatusCodesComparator("default-range-400-600-errors-result.json");
 
     result = tested.compare();
-    assertEquals(ComparatorStepResult.Status.FAILED, result.getStatus());
+    assertEquals(1, result.size());
+    assertEquals(ComparatorStepResult.Status.FAILED, result.get(0).getStatus());
   }
 
   @Test

--- a/core/runner/src/main/java/com/cognifide/aet/runner/processing/data/SuiteDataService.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/processing/data/SuiteDataService.java
@@ -37,22 +37,22 @@ public class SuiteDataService {
   /**
    * @param currentRun - current suite run
    * @return suite wrapper with all patterns from the last or specified (see
-   * Suite.patternCorrelationId) run, if this is the first run of the suite, patterns will be
+   * Suite.patternCorrelationIds) runs, if this is the first run of the suite, patterns will be
    * empty.
    */
   public Suite enrichWithPatterns(final Suite currentRun) throws StorageException {
     final SimpleDBKey dbKey = new SimpleDBKey(currentRun);
     Suite lastVersion = metadataDAO.getLatestRun(dbKey, currentRun.getName());
 
-    List<Suite> pattern = new ArrayList<>();
+    List<Suite> patterns = new ArrayList<>();
     if (hasSharedPatterns(currentRun)) {
       for (String id : currentRun.getPatternCorrelationIds()) {
-        pattern.add(metadataDAO.getSuite(dbKey, id));
+        patterns.add(metadataDAO.getSuite(dbKey, id));
       }
     } else {
-      pattern.add(lastVersion);
+      patterns.add(lastVersion);
     }
-    return SuiteMergeStrategy.merge(currentRun, lastVersion, pattern);
+    return SuiteMergeStrategy.merge(currentRun, lastVersion, patterns);
   }
 
   private boolean hasSharedPatterns(Suite currentRun) {

--- a/core/runner/src/main/java/com/cognifide/aet/runner/processing/data/wrappers/RunIndexWrapper.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/processing/data/wrappers/RunIndexWrapper.java
@@ -38,7 +38,7 @@ public abstract class RunIndexWrapper<T> {
           if (step.getComparators() != null) {
             step.getComparators()
                 .forEach(comparator ->
-                    comparator.setStepResult(null)
+                    comparator.setStepResults(null)
                 );
           }
         });

--- a/core/runner/src/main/java/com/cognifide/aet/runner/processing/steps/CollectionResultsRouter.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/processing/steps/CollectionResultsRouter.java
@@ -123,7 +123,7 @@ public class CollectionResultsRouter extends StepManager implements TaskFinishPo
   }
 
   private void onSuccess(CollectorResultData collectorResultData, String testName,
-      String correlationId) throws JMSException {
+      String patternSuiteCorrelationId) throws JMSException {
     final Url processedUrl = collectorResultData.getUrl();
     updateSuiteUrl(collectorResultData.getTestName(), processedUrl);
     for (Step step : processedUrl.getSteps()) {
@@ -132,7 +132,7 @@ public class CollectionResultsRouter extends StepManager implements TaskFinishPo
         onError(ProcessingError.collectingError(step.getStepResult().getErrors().toString()));
       } else if (hasComparators(step)) {
         if (step.getPatterns().isEmpty()) {
-          step.addPattern(step.getStepResult().getArtifactId(), correlationId);
+          step.addPattern(step.getStepResult().getArtifactId(), patternSuiteCorrelationId);
         }
         int scheduledMessagesNo = dispatch(step, testName, processedUrl.getName());
         LOGGER

--- a/core/runner/src/main/java/com/cognifide/aet/runner/processing/steps/CollectionResultsRouter.java
+++ b/core/runner/src/main/java/com/cognifide/aet/runner/processing/steps/CollectionResultsRouter.java
@@ -131,8 +131,8 @@ public class CollectionResultsRouter extends StepManager implements TaskFinishPo
         LOGGER.error("Step {} finished with errors: {}!", step, step.getStepResult());
         onError(ProcessingError.collectingError(step.getStepResult().getErrors().toString()));
       } else if (hasComparators(step)) {
-        if (StringUtils.isEmpty(step.getPattern())) {
-          step.updatePattern(step.getStepResult().getArtifactId());
+        if (step.getPatterns().isEmpty()) {
+          step.addPatterns(step.getStepResult().getArtifactId());
         }
         int scheduledMessagesNo = dispatch(step, testName, processedUrl.getName());
         LOGGER
@@ -158,7 +158,8 @@ public class CollectionResultsRouter extends StepManager implements TaskFinishPo
   private void createAndSendComparatorJobData(Step step, String testName, String urlName)
       throws JMSException {
     ObjectMessage message = session.createObjectMessage(
-        new ComparatorJobData(runIndexWrapper.get().getCompany(), runIndexWrapper.get().getProject(),
+        new ComparatorJobData(runIndexWrapper.get().getCompany(),
+            runIndexWrapper.get().getProject(),
             runIndexWrapper.get().getName(), testName, urlName, step));
     message.setJMSCorrelationID(correlationId);
     sender.send(message);

--- a/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/SuiteMergeStrategyTest.java
+++ b/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/SuiteMergeStrategyTest.java
@@ -124,8 +124,10 @@ public class SuiteMergeStrategyTest {
     final Suite pattern1 = readSuite(patternResource);
     final Suite pattern2 = readSuite(patternResource);
 
-    pattern1.getTests().get(0).getUrls().iterator().next().getSteps().get(2).addPatterns("foo");
-    pattern2.getTests().get(0).getUrls().iterator().next().getSteps().get(2).addPatterns("zoo");
+    pattern1.getTests().get(0).getUrls().iterator().next().getSteps().get(2)
+        .addPattern("foo", null);
+    pattern2.getTests().get(0).getUrls().iterator().next().getSteps().get(2)
+        .addPattern("zoo", null);
     List<Suite> patterns = Arrays.asList(pattern1, pattern2);
 
     final Suite merged = SuiteMergeStrategy.merge(current, pattern1, patterns);
@@ -147,7 +149,7 @@ public class SuiteMergeStrategyTest {
     final Suite pattern = readSuite(patternResource);
     List<Suite> patterns = Arrays.asList(pattern);
 
-    current.getTests().get(0).getUrls().iterator().next().getSteps().get(4).addPatterns("foo");
+    current.getTests().get(0).getUrls().iterator().next().getSteps().get(4).addPattern("foo", null);
 
     final Suite merged = SuiteMergeStrategy.merge(current, pattern, patterns);
 

--- a/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/SuiteMergeStrategyTest.java
+++ b/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/SuiteMergeStrategyTest.java
@@ -16,9 +16,13 @@
 package com.cognifide.aet.runner.processing.data;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.cognifide.aet.communication.api.metadata.Pattern;
 import com.cognifide.aet.communication.api.metadata.Step;
 import com.cognifide.aet.communication.api.metadata.Suite;
 import com.cognifide.aet.communication.api.metadata.Test;
@@ -29,6 +33,8 @@ import com.googlecode.zohhak.api.Configure;
 import com.googlecode.zohhak.api.TestWith;
 import com.googlecode.zohhak.api.runners.ZohhakRunner;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.junit.runner.RunWith;
@@ -59,7 +65,9 @@ public class SuiteMergeStrategyTest {
     final Url url = test.getUrls().iterator().next();
     final Step desktopScreenStep = url.getSteps().get(2);
 
-    assertThat(desktopScreenStep.getPattern(), is("56ebbed87346a042e67ef462"));
+    assertThat(desktopScreenStep.getPatterns(), hasSize(1));
+    assertThat(desktopScreenStep.getPatterns().iterator().next().getPattern(),
+        is("56ebbed87346a042e67ef462"));
   }
 
   @TestWith({"conversion/current.json"})
@@ -86,7 +94,71 @@ public class SuiteMergeStrategyTest {
 
     final Step desktopMobileNewStep = steps.get(4);
     assertThat(desktopMobileNewStep.getType(), is("screen"));
-    assertNull(desktopMobileNewStep.getPattern());
+    assertThat(desktopMobileNewStep.getPatterns(), empty());
+  }
+
+  @TestWith({"conversion/pattern.json;conversion/current.json"})
+  public void merge_addSinglePatternWhenMultipleSamePatternSuitesProvided(String patternResource,
+      String currentResource) throws IOException {
+    final Suite current = readSuite(currentResource);
+    final Suite pattern1 = readSuite(patternResource);
+    final Suite pattern2 = readSuite(patternResource);
+    final List<Suite> patterns = Arrays.asList(pattern1, pattern2);
+
+    final Suite merged = SuiteMergeStrategy.merge(current, pattern1, patterns);
+
+    final Test test = merged.getTests().get(0);
+    final Url url = test.getUrls().iterator().next();
+
+    final List<Step> steps = url.getSteps();
+    assertThat(steps.size(), is(5));
+
+    final Step step = steps.get(2);
+    assertThat(step.getPatterns(), hasSize(1));
+  }
+
+  @TestWith({"conversion/pattern.json;conversion/current.json"})
+  public void merge_addAllPatternsWhenMultipleDifferentPatternSuitesProvided(String patternResource,
+      String currentResource) throws IOException {
+    final Suite current = readSuite(currentResource);
+    final Suite pattern1 = readSuite(patternResource);
+    final Suite pattern2 = readSuite(patternResource);
+
+    pattern1.getTests().get(0).getUrls().iterator().next().getSteps().get(2).addPatterns("foo");
+    pattern2.getTests().get(0).getUrls().iterator().next().getSteps().get(2).addPatterns("zoo");
+    List<Suite> patterns = Arrays.asList(pattern1, pattern2);
+
+    final Suite merged = SuiteMergeStrategy.merge(current, pattern1, patterns);
+
+    final Test test = merged.getTests().get(0);
+    final Url url = test.getUrls().iterator().next();
+
+    final List<Step> steps = url.getSteps();
+    assertThat(steps.size(), is(5));
+
+    final Step step = steps.get(2);
+    assertThat(step.getPatterns(), hasSize(3));
+  }
+
+  @TestWith({"conversion/pattern.json;conversion/current.json"})
+  public void merge_shouldNotErasePatternInCurrent_whenNoStepsIntersectInSuites(
+      String patternResource, String currentResource) throws IOException {
+    final Suite current = readSuite(currentResource);
+    final Suite pattern = readSuite(patternResource);
+    List<Suite> patterns = Arrays.asList(pattern);
+
+    current.getTests().get(0).getUrls().iterator().next().getSteps().get(4).addPatterns("foo");
+
+    final Suite merged = SuiteMergeStrategy.merge(current, pattern, patterns);
+
+    final Test test = merged.getTests().get(0);
+    final Url url = test.getUrls().iterator().next();
+
+    final List<Step> steps = url.getSteps();
+    assertThat(steps.size(), is(5));
+
+    final Step nonIntersectingStep = steps.get(4);
+    assertThat(nonIntersectingStep.getPatterns(), hasSize(1));
   }
 
   private Suite readSuite(String resource) throws IOException {

--- a/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/wrappers/RunIndexWrapperTest.java
+++ b/core/runner/src/test/java/com/cognifide/aet/runner/processing/data/wrappers/RunIndexWrapperTest.java
@@ -35,6 +35,7 @@ import com.cognifide.aet.communication.api.metadata.Suite;
 import com.cognifide.aet.communication.api.metadata.Url;
 import com.cognifide.aet.communication.api.wrappers.Run;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -68,7 +69,7 @@ public class RunIndexWrapperTest {
     runIndexWrapper = new SuiteRunIndexWrapper(objectToRunWrapper);
     test = Optional
         .of(new com.cognifide.aet.communication.api.metadata.Test("testName", "proxy", "chrome"));
-    url = Optional.of(new Url("urlName","urlUrl","urlDomain"));
+    url = Optional.of(new Url("urlName", "urlUrl", "urlDomain"));
     test.get().addUrl(url.get());
   }
 
@@ -80,7 +81,8 @@ public class RunIndexWrapperTest {
     realUrl.addStep(step);
 
     Comparator comparator = new Comparator("comparatorType");
-    comparator.setStepResult(new ComparatorStepResult("comparatorStepResultName", Status.PASSED));
+    comparator.setStepResults(Collections.singletonList(
+        new ComparatorStepResult("comparatorStepResultName", Status.PASSED)));
     ArrayList<Operation> listOperation = new ArrayList<>();
     listOperation.add(new Operation("operationType"));
     comparator.setFilters(listOperation);
@@ -97,7 +99,7 @@ public class RunIndexWrapperTest {
     assertEquals(realUrl.getDomain(), "urlDomain");
     assertNull(realUrl.getCollectionStats());
     verify(step, times(1)).setStepResult(null);
-    assertNull(comparator.getStepResult());
+    assertNull(comparator.getStepResults());
     assertEquals(comparator.getFilters().size(), 1);
   }
 
@@ -123,7 +125,7 @@ public class RunIndexWrapperTest {
     assertNull(realUrl.getCollectionStats());
     assertEquals(realUrl.getSteps().size(), 1);
     verify(step, times(1)).setStepResult(null);
-    assertNull(comparator.getStepResult());
+    assertNull(comparator.getStepResults());
     assertEquals(comparator.getFilters().size(), 1);
   }
 

--- a/core/runner/src/test/resources/conversion/pattern.json
+++ b/core/runner/src/test/resources/conversion/pattern.json
@@ -51,7 +51,7 @@
               "comparators": [
                 {
                   "comment": "screen comparator level comment",
-                  "stepResult": [
+                  "stepResults": [
                     {
                       "status": "PASSED"
                     }
@@ -92,7 +92,7 @@
               },
               "comparators": [
                 {
-                  "stepResult": [
+                  "stepResults": [
                     {
                       "status": "PASSED"
                     }

--- a/core/runner/src/test/resources/conversion/pattern.json
+++ b/core/runner/src/test/resources/conversion/pattern.json
@@ -51,9 +51,11 @@
               "comparators": [
                 {
                   "comment": "screen comparator level comment",
-                  "stepResult": {
-                    "status": "PASSED"
-                  },
+                  "stepResult": [
+                    {
+                      "status": "PASSED"
+                    }
+                  ],
                   "type": "screen",
                   "parameters": {
                     "comparator": "layout"
@@ -90,9 +92,11 @@
               },
               "comparators": [
                 {
-                  "stepResult": {
-                    "status": "PASSED"
-                  },
+                  "stepResult": [
+                    {
+                      "status": "PASSED"
+                    }
+                  ],
                   "filters": [
                     {
                       "type": "extract-element",

--- a/core/runner/src/test/resources/conversion/pattern.json
+++ b/core/runner/src/test/resources/conversion/pattern.json
@@ -1,28 +1,28 @@
 {
-  "correlationId" : "unittest-project-0",
-  "company" : "unittest",
-  "project" : "project",
-  "name" : "unitTestingSuite",
-  "version" : 1,
-  "tests" : [
+  "correlationId": "unittest-project-0",
+  "company": "unittest",
+  "project": "project",
+  "name": "unitTestingSuite",
+  "version": 1,
+  "tests": [
     {
-      "name" : "test-one",
-      "comment" : "test level comment",
-      "urls" : [
+      "name": "test-one",
+      "comment": "test level comment",
+      "urls": [
         {
-          "name" : "/our-company",
-          "url" : "/our-company",
-          "canonicalUrl" : "/our-company",
-          "domain" : "https://cognifide.com",
-          "comment" : "url level comment",
-          "steps" : [
+          "name": "/our-company",
+          "url": "/our-company",
+          "canonicalUrl": "/our-company",
+          "domain": "https://cognifide.com",
+          "comment": "url level comment",
+          "steps": [
             {
-              "index" : 0,
-              "name" : "open",
-              "stepResult" : {
-                "status" : "PAGE_OPENED"
+              "index": 0,
+              "name": "open",
+              "stepResult": {
+                "status": "PAGE_OPENED"
               },
-              "type" : "open"
+              "type": "open"
             },
             {
               "index": 1,
@@ -36,29 +36,33 @@
               }
             },
             {
-              "index" : 2,
-              "name" : "desktop",
-              "comment" : "step level comment",
-              "pattern" : "56ebbed87346a042e67ef462",
-              "stepResult" : {
-                "status" : "COLLECTED",
-                "artifactId" : "56ebbed87346a042e67ef462"
-              },
-              "comparators" : [
+              "index": 2,
+              "name": "desktop",
+              "comment": "step level comment",
+              "patterns": [
                 {
-                  "comment" : "screen comparator level comment",
-                  "stepResult" : {
-                    "status" : "PASSED"
+                  "pattern": "56ebbed87346a042e67ef462"
+                }
+              ],
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56ebbed87346a042e67ef462"
+              },
+              "comparators": [
+                {
+                  "comment": "screen comparator level comment",
+                  "stepResult": {
+                    "status": "PASSED"
                   },
-                  "type" : "screen",
-                  "parameters" : {
-                    "comparator" : "layout"
+                  "type": "screen",
+                  "parameters": {
+                    "comparator": "layout"
                   }
                 }
               ],
-              "type" : "screen",
-              "parameters" : {
-                "name" : "desktop"
+              "type": "screen",
+              "parameters": {
+                "name": "desktop"
               }
             },
             {
@@ -73,33 +77,37 @@
               }
             },
             {
-              "index" : 4,
-              "name" : "source",
-              "pattern" : "56f3b0a978139e1e6dabcd0e",
-              "stepResult" : {
-                "status" : "COLLECTED",
-                "artifactId" : "56f3b0a978139e1e6dabcd0e"
-              },
-              "comparators" : [
+              "index": 4,
+              "name": "source",
+              "patterns": [
                 {
-                  "stepResult" : {
-                    "status" : "PASSED"
+                  "pattern": "56f3b0a978139e1e6dabcd0e"
+                }
+              ],
+              "stepResult": {
+                "status": "COLLECTED",
+                "artifactId": "56f3b0a978139e1e6dabcd0e"
+              },
+              "comparators": [
+                {
+                  "stepResult": {
+                    "status": "PASSED"
                   },
-                  "filters" : [
+                  "filters": [
                     {
-                      "type" : "extract-element",
-                      "parameters" : {
-                        "elementId" : "date-panel"
+                      "type": "extract-element",
+                      "parameters": {
+                        "elementId": "date-panel"
                       }
                     }
                   ],
-                  "type" : "source",
-                  "parameters" : {
-                    "comparator" : "source"
+                  "type": "source",
+                  "parameters": {
+                    "comparator": "source"
                   }
                 }
               ],
-              "type" : "source"
+              "type": "source"
             }
           ]
         }

--- a/core/worker/src/main/java/com/cognifide/aet/worker/impl/CollectorDispatcherImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/impl/CollectorDispatcherImpl.java
@@ -110,7 +110,7 @@ public class CollectorDispatcherImpl implements CollectorDispatcher {
     final String collectorType = currentStep.getType();
     if (jobRegistry.hasJob(collectorType)) {
       CollectorProperties collectorProperties = new CollectorProperties(urlWithDomain,
-          jobData.getCompany(), jobData.getProject(), currentStep.getPattern());
+          jobData.getCompany(), jobData.getProject(), currentStep.getPatterns());
       return jobRegistry.getCollectorFactory(collectorType)
           .createInstance(collectorProperties, currentStep.getParameters(),
               webCommunicationWrapper);

--- a/core/worker/src/main/java/com/cognifide/aet/worker/listeners/ComparatorMessageListenerImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/listeners/ComparatorMessageListenerImpl.java
@@ -84,7 +84,7 @@ public class ComparatorMessageListenerImpl extends AbstractTaskMessageListener {
       final Step step = comparatorJobData.getStep();
       final ComparatorProperties properties = new ComparatorProperties(
           comparatorJobData.getCompany(),
-          comparatorJobData.getProject(), step.getPattern(), step.getStepResult().getArtifactId(), step.getStepResult().getPayload());
+          comparatorJobData.getProject(), step.getPatterns(), step.getStepResult().getArtifactId(), step.getStepResult().getPayload());
 
       for (Comparator comparator : step.getComparators()) {
         LOGGER.info("Start comparison for comparator {} in step {}", comparator, step);

--- a/core/worker/src/main/java/com/cognifide/aet/worker/listeners/ComparatorMessageListenerImpl.java
+++ b/core/worker/src/main/java/com/cognifide/aet/worker/listeners/ComparatorMessageListenerImpl.java
@@ -26,6 +26,7 @@ import com.cognifide.aet.communication.api.queues.JmsConnection;
 import com.cognifide.aet.job.api.comparator.ComparatorProperties;
 import com.cognifide.aet.queues.JmsUtils;
 import com.cognifide.aet.worker.api.ComparatorDispatcher;
+import java.util.Collections;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import org.apache.commons.lang3.StringUtils;
@@ -83,8 +84,8 @@ public class ComparatorMessageListenerImpl extends AbstractTaskMessageListener {
           comparatorJobData.getUrlName());
       final Step step = comparatorJobData.getStep();
       final ComparatorProperties properties = new ComparatorProperties(
-          comparatorJobData.getCompany(),
-          comparatorJobData.getProject(), step.getPatterns(), step.getStepResult().getArtifactId(), step.getStepResult().getPayload());
+          comparatorJobData.getCompany(), comparatorJobData.getProject(), step.getPatterns(),
+          step.getStepResult().getArtifactId(), step.getStepResult().getPayload());
 
       for (Comparator comparator : step.getComparators()) {
         LOGGER.info("Start comparison for comparator {} in step {}", comparator, step);
@@ -106,7 +107,7 @@ public class ComparatorMessageListenerImpl extends AbstractTaskMessageListener {
           final ComparatorStepResult errorResult =
               new ComparatorStepResult(null, ComparatorStepResult.Status.PROCESSING_ERROR);
           errorResult.addError(e.getMessage());
-          comparator.setStepResult(errorResult);
+          comparator.setStepResults(Collections.singletonList(errorResult));
           resultBuilder.withStatus(JobStatus.ERROR)
               .withComparisonResult(comparator)
               .withProcessingError(ProcessingError.comparingError(e.getMessage()));

--- a/report/src/main/webapp/app/layout/main/url/navigation/navigation.patternButtons.html
+++ b/report/src/main/webapp/app/layout/main/url/navigation/navigation.patternButtons.html
@@ -17,19 +17,7 @@
     limitations under the License.
 
 -->
-<div class="toolbar-btns pull-right" data-ng-if=" case.usesCrossSuitePattern ">
-  <div class="button button-small button-dark button-disabled"
-       ng-if="case.showAcceptButton"
-       data-aet-included-comment-popover
-       data-toggle="popover"
-       data-content="May not be accepted because compared against another suite patterns."
-       data-html="true"
-       data-trigger="hover">
-    <i class="icon icon-rebase"></i>
-    Accept test case
-  </div>
-</div>
-<div class="toolbar-btns pull-right" data-ng-if=" !case.usesCrossSuitePattern ">
+<div class="toolbar-btns pull-right">
   <div class="button button-small js-test-rebase button-blue" ng-click="urlView.acceptCase(case)"
        ng-if="case.showAcceptButton">
     <i class="icon icon-rebase"></i>

--- a/report/src/main/webapp/app/layout/toolbar/toolbarBottom.controller.js
+++ b/report/src/main/webapp/app/layout/toolbar/toolbarBottom.controller.js
@@ -28,11 +28,6 @@ define([], function () {
     suiteInfoService, rerunService, historyService) {
     var vm = this;
 
-    // disables accept button if compared against another suite patterns
-    if (suiteInfoService.getInfo().patternCorrelationId) {
-      vm.usesCrossSuitePattern = true;
-    }
-
     vm.showAcceptButton = patternsMayBeUpdated;
     vm.showRevertButton = patternsMarkedForUpdateMayBeReverted;
     vm.displayCommentModal = displayCommentModal;
@@ -92,9 +87,6 @@ define([], function () {
           vm.model.patternsToAccept - vm.model.acceptedPatterns;
         result = patternsToAcceptLeft > 0;
       }
-      if (vm.usesCrossSuitePattern) {
-        result = false;
-      }
       return result;
 
     }
@@ -105,9 +97,6 @@ define([], function () {
         result =
           vm.model.acceptedPatterns > 0 &&
           vm.model.acceptedPatterns <= vm.model.patternsToAccept;
-      }
-      if (vm.usesCrossSuitePattern) {
-        result = false;
       }
       return result;
     }

--- a/report/src/main/webapp/app/layout/toolbar/toolbarBottom.view.html
+++ b/report/src/main/webapp/app/layout/toolbar/toolbarBottom.view.html
@@ -128,16 +128,6 @@
           </div>
       </span>
 
-      <span class="button button-dark button-disabled"
-            data-ng-if="toolbarBottom.usesCrossSuitePattern"
-            data-aet-included-comment-popover
-            data-toggle="popover"
-            data-content="May not be accepted because compared against another suite patterns."
-            data-html="true"
-            data-trigger="hover"></i>
-        Accept {{toolbarBottom.viewMode}}
-      </span>
-    
       <span class="button js-rebase-suite button-blue"
             data-ng-if="toolbarBottom.showAcceptButton()"
             data-ng-click="toolbarBottom.updatePatterns()"></i>

--- a/report/src/main/webapp/package-lock.json
+++ b/report/src/main/webapp/package-lock.json
@@ -130,7 +130,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -2355,7 +2355,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -4257,7 +4257,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -4290,7 +4290,7 @@
     "es5-ext": {
       "version": "0.10.45",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -7508,7 +7508,7 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "htmlescape": {
@@ -7682,7 +7682,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inline-source-map": {
@@ -8753,7 +8753,7 @@
     "lockfile": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha1-B/gZ0lrkj4flOOZXi2lkpJgaVgk=",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "dev": true,
       "requires": {
         "signal-exit": "^3.0.2"
@@ -9563,7 +9563,7 @@
     "natives": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha1-Lw8iT8mn3VNAfHZnyEz42+dz3lg=",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg==",
       "dev": true
     },
     "natural-compare": {
@@ -9753,7 +9753,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -9780,7 +9780,7 @@
     "npmconf": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.3.tgz",
-      "integrity": "sha1-HL5d0C6JnTZf7XJgtUBVRz+QoVw=",
+      "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
       "dev": true,
       "requires": {
         "config-chain": "~1.1.8",
@@ -11415,7 +11415,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-regex": {
@@ -11430,7 +11430,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "sass-graph": {
@@ -12051,7 +12051,7 @@
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-      "integrity": "sha1-BaW01xU6GVvJLDxCW2nzsqlSTII=",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -12061,13 +12061,13 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha1-LHrmEFbHFKW5ubKyr30xHvXHj+k=",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -12077,7 +12077,7 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha1-enzShHDMbToc/m1miG9rxDDTrIc=",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "split-string": {
@@ -12444,7 +12444,7 @@
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI=",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {
@@ -12749,7 +12749,7 @@
     "timers-ext": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
-      "integrity": "sha1-dxR91OdrZgwqu4eF25ZXTLvRKSI=",
+      "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
       "dev": true,
       "requires": {
         "es5-ext": "~0.10.14",

--- a/rest-endpoint/src/main/java/com/cognifide/aet/rest/MetadataServlet.java
+++ b/rest-endpoint/src/main/java/com/cognifide/aet/rest/MetadataServlet.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -174,11 +175,11 @@ public class MetadataServlet extends BasicDataServlet {
         new InputStreamReader(req.getInputStream(), StandardCharsets.UTF_8));
     Suite suite = Suite.fromJson(reader);
     checkLock(suite.getSuiteIdentifier());
-    checkAnotherSuitePattern(suite.getPatternCorrelationId());
+    checkAnotherSuitePatterns(suite.getPatternCorrelationIds());
     metadataDAO.updateSuite(suite);
   }
 
-  private void checkAnotherSuitePattern(String patternCorrelationId) throws AETException {
+  private void checkAnotherSuitePatterns(Set<String> patternCorrelationId) throws AETException {
     if (patternCorrelationId != null) {
       String msg = "Accepting changes not allowed as comparison was done against another suite: '";
       msg += patternCorrelationId + "'.";

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteExecutor.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import javax.jms.JMSException;
@@ -123,21 +124,21 @@ public class SuiteExecutor {
    *
    * @param suiteString - content of the test suite XML file
    * @param domain - overrides domain defined in the suite file
-   * @param patternCorrelationId - optional pattern to set, this is a correlation ID of a suite that
-   * will be used as patterns source
-   * @param patternSuite - optional pattern to set, this is a name of a suite whose latest version
-   * will be used as patterns source. This parameter is ignored if patternCorrelationId is set
+   * @param patternCorrelationId - optional collection of correlation IDs of suites that will be
+   * used as patterns sources
+   * @param patternSuite - optional collection of names of suites whose latest versions will be used
+   * as patterns sources.
    * @return status of the suite execution
    */
   HttpSuiteExecutionResultWrapper execute(String suiteString, String name, String domain,
-      String patternCorrelationId, String patternSuite) {
+      Set<String> patternCorrelationId, Set<String> patternSuite) {
     HttpSuiteExecutionResultWrapper result;
     TestSuiteParser xmlFileParser = new XmlTestSuiteParser();
     try {
       TestSuiteRun testSuiteRun = xmlFileParser.parse(suiteString);
       testSuiteRun = overrideDomainOrNameIfDefined(testSuiteRun, name, domain);
-      testSuiteRun.setPatternCorrelationId(patternCorrelationId);
-      testSuiteRun.setPatternSuite(patternSuite);
+      testSuiteRun.setPatternsCorrelationIds(patternCorrelationId);
+      testSuiteRun.setPatternsSuite(patternSuite);
 
       String validationError = suiteValidator.validateTestSuiteRun(testSuiteRun);
       if (validationError == null) {
@@ -177,7 +178,8 @@ public class SuiteExecutor {
       String statusUrl = getStatusUrl(objectToRunWrapper);
       String htmlReportUrl = getReportUrl(HTML_REPORT_URL_FORMAT,
           reportConfigurationManager.getReportDomain(), objectToRunWrapper);
-      String xunitReportUrl = getReportUrl(XUNIT_REPORT_URL_FORMAT, StringUtils.EMPTY, objectToRunWrapper);
+      String xunitReportUrl = getReportUrl(XUNIT_REPORT_URL_FORMAT, StringUtils.EMPTY,
+          objectToRunWrapper);
       return HttpSuiteExecutionResultWrapper.wrap(
           SuiteExecutionResult.createSuccessResult(objectToRunWrapper.getCorrelationId(), statusUrl,
               htmlReportUrl, xunitReportUrl));

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteServlet.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -118,7 +119,7 @@ public class SuiteServlet extends HttpServlet {
   private String getSingletonParam(Multimap<String, String> data, String paramName) {
     try {
       return data.get(paramName).iterator().next();
-    } catch (NullPointerException e) {
+    } catch (NoSuchElementException | NullPointerException e) {
       return null;
     }
   }

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteValidator.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteValidator.java
@@ -25,6 +25,8 @@ import com.cognifide.aet.vs.SimpleDBKey;
 import com.cognifide.aet.vs.StorageException;
 import com.google.common.base.Joiner;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,28 +46,25 @@ public class SuiteValidator {
   private MetadataDAO metadataDAO;
 
   public SuiteValidator() {
-    // default constructor
   }
 
-  // for unit tests
   SuiteValidator(MetadataDAO metadataDAO) {
     this.metadataDAO = metadataDAO;
   }
 
   public String validateTestSuiteRun(TestSuiteRun testSuiteRun) {
-    boolean patternFromSameProject = isPatternFromSameProject(testSuiteRun);
-    if (!patternFromSameProject) {
+    Set<String> differentProjectPatterns = getAnyPatternsFromDifferentProject(testSuiteRun);
+    if (!differentProjectPatterns.isEmpty()) {
       return String
-          .format("Incorrect pattern: '%s'. Must belong to same company (%s) and project (%s).",
-              testSuiteRun.getPatternsCorrelationIds(),
+          .format("Incorrect patterns: '%s'. Must belong to same company (%s) and project (%s).",
+              differentProjectPatterns.toString(),
               testSuiteRun.getCompany(),
               testSuiteRun.getProject());
     }
-    boolean patternValid = isPatternInDatabase(testSuiteRun);
-    if (!patternValid) {
+    Set<String> notFoundPatterns = anyPatternsNotInDatabase(testSuiteRun);
+    if (!notFoundPatterns.isEmpty()) {
       return String
-          .format("Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
-              testSuiteRun.getPatternsCorrelationIds(), testSuiteRun.getPatternsSuite());
+          .format("Incorrect patterns: '%s'. Not found in database.", notFoundPatterns.toString());
     }
     for (TestRun testRun : testSuiteRun.getTestRunMap().values()) {
       if (hasScreenCollector(testRun) && !hasScreenComparator(testRun)) {
@@ -78,15 +77,20 @@ public class SuiteValidator {
   }
 
   /**
-   * Validates if the pattern is from the same project and company. This is because currently AET is
+   * Validates if patterns are from the same project and company. This is because currently AET is
    * not supporting cross-projects patterns.
    *
    * @param testSuiteRun suite to be tested
    * @return true if suite is OK
    */
-  private boolean isPatternFromSameProject(TestSuiteRun testSuiteRun) {
+  private Set<String> getAnyPatternsFromDifferentProject(TestSuiteRun testSuiteRun) {
+    return testSuiteRun.getPatternsCorrelationIds().stream()
+        .filter(pattern -> !isPatternFromSameProject(testSuiteRun, pattern))
+        .collect(Collectors.toSet());
+  }
+
+  private boolean isPatternFromSameProject(TestSuiteRun testSuiteRun, String pattern) {
     boolean sameProject;
-    String pattern = testSuiteRun.getPatternsCorrelationIds();
     if (pattern == null) {
       // patterns will be taken from same suite automatically
       sameProject = true;
@@ -121,30 +125,46 @@ public class SuiteValidator {
     return false;
   }
 
-  private boolean isPatternInDatabase(TestSuiteRun testSuiteRun) {
-    boolean valid = false;
-    SimpleDBKey dbKey = new SimpleDBKey(testSuiteRun.getCompany(), testSuiteRun.getProject());
-    String patternCorrelationId = testSuiteRun.getPatternsCorrelationIds();
-    String patternSuiteName = testSuiteRun.getPatternsSuite();
-    if (patternCorrelationId == null && patternSuiteName == null) {
-      valid = true;
-    } else {
-      Suite patternSuite = null;
-      try {
-        if (patternCorrelationId != null) {
-          patternSuite = metadataDAO.getSuite(dbKey, patternCorrelationId);
-        } else {
-          patternSuite = metadataDAO.getLatestRun(dbKey, patternSuiteName);
-        }
-      } catch (StorageException se) {
-        LOG.error(
-            "error while retrieving suite from mongo db: '{}', correlationId: '{}', suiteName: '{}'",
-            dbKey, patternCorrelationId, patternSuiteName, se);
-      }
-      if (patternSuite != null) {
-        valid = true;
-      }
-    }
-    return valid;
+  private Set<String> anyPatternsNotInDatabase(TestSuiteRun testSuiteRun) {
+    Set<String> notFoundPatterns = testSuiteRun.getPatternsCorrelationIds().stream()
+        .filter(id -> !isPatternCorrelationIdInDatabase(testSuiteRun, id))
+        .collect(Collectors.toSet());
+
+    notFoundPatterns.addAll(testSuiteRun.getPatternsSuite().stream()
+        .filter(pattern -> !isPatternSuiteInDatabase(testSuiteRun, pattern))
+        .collect(Collectors.toSet()));
+
+    return notFoundPatterns;
   }
+
+  private boolean isPatternCorrelationIdInDatabase(TestSuiteRun testSuiteRun,
+      String patternCorrelationId) {
+    return isInDatabase(testSuiteRun, patternCorrelationId, true);
+  }
+
+  private boolean isPatternSuiteInDatabase(TestSuiteRun testSuiteRun, String patternSuiteName) {
+    return isInDatabase(testSuiteRun, patternSuiteName, false);
+  }
+
+  private boolean isInDatabase(TestSuiteRun testSuiteRun, String identifier,
+      boolean isCorrelationId) {
+    SimpleDBKey dbKey = new SimpleDBKey(testSuiteRun.getCompany(), testSuiteRun.getProject());
+    try {
+      Suite patternSuite;
+      if (isCorrelationId) {
+        patternSuite = metadataDAO.getSuite(dbKey, identifier);
+      } else {
+        patternSuite = metadataDAO.getLatestRun(dbKey, identifier);
+      }
+
+      return patternSuite != null;
+
+    } catch (StorageException se) {
+      LOG.error(
+          "error while retrieving suite from mongo db: '{}', suiteName: '{}'",
+          dbKey, identifier, se);
+      return false;
+    }
+  }
+
 }

--- a/test-executor/src/main/java/com/cognifide/aet/executor/SuiteValidator.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/SuiteValidator.java
@@ -57,7 +57,7 @@ public class SuiteValidator {
     if (!patternFromSameProject) {
       return String
           .format("Incorrect pattern: '%s'. Must belong to same company (%s) and project (%s).",
-              testSuiteRun.getPatternCorrelationId(),
+              testSuiteRun.getPatternsCorrelationIds(),
               testSuiteRun.getCompany(),
               testSuiteRun.getProject());
     }
@@ -65,7 +65,7 @@ public class SuiteValidator {
     if (!patternValid) {
       return String
           .format("Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
-              testSuiteRun.getPatternCorrelationId(), testSuiteRun.getPatternSuite());
+              testSuiteRun.getPatternsCorrelationIds(), testSuiteRun.getPatternsSuite());
     }
     for (TestRun testRun : testSuiteRun.getTestRunMap().values()) {
       if (hasScreenCollector(testRun) && !hasScreenComparator(testRun)) {
@@ -86,7 +86,7 @@ public class SuiteValidator {
    */
   private boolean isPatternFromSameProject(TestSuiteRun testSuiteRun) {
     boolean sameProject;
-    String pattern = testSuiteRun.getPatternCorrelationId();
+    String pattern = testSuiteRun.getPatternsCorrelationIds();
     if (pattern == null) {
       // patterns will be taken from same suite automatically
       sameProject = true;
@@ -124,8 +124,8 @@ public class SuiteValidator {
   private boolean isPatternInDatabase(TestSuiteRun testSuiteRun) {
     boolean valid = false;
     SimpleDBKey dbKey = new SimpleDBKey(testSuiteRun.getCompany(), testSuiteRun.getProject());
-    String patternCorrelationId = testSuiteRun.getPatternCorrelationId();
-    String patternSuiteName = testSuiteRun.getPatternSuite();
+    String patternCorrelationId = testSuiteRun.getPatternsCorrelationIds();
+    String patternSuiteName = testSuiteRun.getPatternsSuite();
     if (patternCorrelationId == null && patternSuiteName == null) {
       valid = true;
     } else {

--- a/test-executor/src/main/java/com/cognifide/aet/executor/model/TestSuiteRun.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/model/TestSuiteRun.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents whole test suite. Consists of tests and list of reports that will be generated after
@@ -43,9 +44,9 @@ public class TestSuiteRun implements Serializable {
 
   private Long version;
 
-  private String patternCorrelationId;
+  private Set<String> patternsCorrelationIds;
 
-  private String patternSuite;
+  private Set<String> patternsSuite;
 
   /**
    * Parameters: name, company, project are part of identifier of test suite.
@@ -152,19 +153,19 @@ public class TestSuiteRun implements Serializable {
         .add("version", version).toString();
   }
 
-  public void setPatternCorrelationId(String patternCorrelationId) {
-    this.patternCorrelationId = patternCorrelationId;
+  public void setPatternsCorrelationIds(Set<String> patternsCorrelationIds) {
+    this.patternsCorrelationIds = patternsCorrelationIds;
   }
 
-  public String getPatternCorrelationId() {
-    return patternCorrelationId;
+  public Set<String> getPatternsCorrelationIds() {
+    return patternsCorrelationIds;
   }
 
-  public String getPatternSuite() {
-    return patternSuite;
+  public Set<String> getPatternsSuite() {
+    return patternsSuite;
   }
 
-  public void setPatternSuite(String patternSuite) {
-    this.patternSuite = patternSuite;
+  public void setPatternsSuite(Set<String> patternSuite) {
+    this.patternsSuite = patternSuite;
   }
 }

--- a/test-executor/src/test/java/com/cognifide/aet/executor/SuiteFactoryTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/SuiteFactoryTest.java
@@ -20,6 +20,7 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
@@ -76,7 +77,8 @@ public class SuiteFactoryTest {
     assertThat(suite.getProject(), equalTo(PROJECT));
     assertThat(suite.getName(), equalTo(SUITE_NAME));
     assertThat(suite.getCorrelationId(), equalTo(CORRELATION_ID));
-    assertThat(suite.getPatternCorrelationIds(), equalTo(patternCorrelationId));
+    assertThat(suite.getPatternCorrelationIds().iterator().next(), equalTo(patternCorrelationId));
+    assertThat(suite.getPatternCorrelationIds(), hasSize(1));
   }
 
   @Test
@@ -99,8 +101,8 @@ public class SuiteFactoryTest {
     String patternCorrelationId2 = "company-project-other-suite-123456789";
     String patternSuiteName = "other-suite";
 
-    when(patternSuite.getPatternCorrelationIds())
-        .thenReturn(Collections.singleton(patternCorrelationId1));
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(
+        Collections.singleton(patternCorrelationId1));
     when(testSuiteRun.getPatternsSuite()).thenReturn(Collections.singleton(patternSuiteName));
     when(metadataDAO.getLatestRun(any(), eq(patternSuiteName))).thenReturn(patternSuite);
     when(patternSuite.getCorrelationId()).thenReturn(patternCorrelationId2);
@@ -108,6 +110,6 @@ public class SuiteFactoryTest {
     Suite suite = suiteFactory.suiteFromTestSuiteRun(testSuiteRun);
 
     assertThat(suite.getPatternCorrelationIds(),
-        contains(new HashSet<>(Arrays.asList(patternCorrelationId1, patternCorrelationId2))));
+        contains(patternCorrelationId1, patternCorrelationId2));
   }
 }

--- a/test-executor/src/test/java/com/cognifide/aet/executor/SuiteFactoryTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/SuiteFactoryTest.java
@@ -15,7 +15,10 @@
  */
 package com.cognifide.aet.executor;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -25,6 +28,9 @@ import com.cognifide.aet.communication.api.metadata.Suite;
 import com.cognifide.aet.executor.model.TestSuiteRun;
 import com.cognifide.aet.vs.MetadataDAO;
 import com.cognifide.aet.vs.StorageException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,14 +68,15 @@ public class SuiteFactoryTest {
   @Test
   public void suiteFromTestSuiteRun_whenValidTestSuite_expectSameFieldsInResult() {
     String patternCorrelationId = "company-project-other-suite-012345678";
-    when(testSuiteRun.getPatternCorrelationId()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(
+        Collections.singleton(patternCorrelationId));
 
     Suite suite = suiteFactory.suiteFromTestSuiteRun(testSuiteRun);
     assertThat(suite.getCompany(), equalTo(COMPANY));
     assertThat(suite.getProject(), equalTo(PROJECT));
     assertThat(suite.getName(), equalTo(SUITE_NAME));
     assertThat(suite.getCorrelationId(), equalTo(CORRELATION_ID));
-    assertThat(suite.getPatternCorrelationId(), equalTo(patternCorrelationId));
+    assertThat(suite.getPatternCorrelationIds(), equalTo(patternCorrelationId));
   }
 
   @Test
@@ -77,12 +84,30 @@ public class SuiteFactoryTest {
       throws StorageException {
     String patternCorrelationId = "company-project-other-suite-012345678";
     String patternSuiteName = "other-suite";
-    when(testSuiteRun.getPatternSuite()).thenReturn(patternSuiteName);
+    when(testSuiteRun.getPatternsSuite()).thenReturn(Collections.singleton(patternSuiteName));
     when(metadataDAO.getLatestRun(any(), eq(patternSuiteName))).thenReturn(patternSuite);
     when(patternSuite.getCorrelationId()).thenReturn(patternCorrelationId);
 
     Suite suite = suiteFactory.suiteFromTestSuiteRun(testSuiteRun);
-    assertThat(suite.getPatternCorrelationId(), equalTo(patternCorrelationId));
+    assertThat(suite.getPatternCorrelationIds(), contains(patternCorrelationId));
   }
 
+  @Test
+  public void suiteFromTestSuiteRun_whenCorrelationIdAndSuiteNameProvided_expectBothToBeFetched()
+      throws StorageException {
+    String patternCorrelationId1 = "company-project-other-suite-012345678";
+    String patternCorrelationId2 = "company-project-other-suite-123456789";
+    String patternSuiteName = "other-suite";
+
+    when(patternSuite.getPatternCorrelationIds())
+        .thenReturn(Collections.singleton(patternCorrelationId1));
+    when(testSuiteRun.getPatternsSuite()).thenReturn(Collections.singleton(patternSuiteName));
+    when(metadataDAO.getLatestRun(any(), eq(patternSuiteName))).thenReturn(patternSuite);
+    when(patternSuite.getCorrelationId()).thenReturn(patternCorrelationId2);
+
+    Suite suite = suiteFactory.suiteFromTestSuiteRun(testSuiteRun);
+
+    assertThat(suite.getPatternCorrelationIds(),
+        contains(new HashSet<>(Arrays.asList(patternCorrelationId1, patternCorrelationId2))));
+  }
 }

--- a/test-executor/src/test/java/com/cognifide/aet/executor/SuiteValidatorTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/SuiteValidatorTest.java
@@ -18,6 +18,7 @@ package com.cognifide.aet.executor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -68,10 +69,11 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternIdFromDifferentProject_expectError() {
     String patternCorrelationId = "company1-project1-suite-name-123456789";
-    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(
+        Collections.singleton(patternCorrelationId));
 
     String errorMessage = String.format(
-        "Incorrect pattern: '%s'. Must belong to same company (%s) and project (%s).",
+        "Incorrect patterns: '[%s]'. Must belong to same company (%s) and project (%s).",
         patternCorrelationId, COMPANY, PROJECT);
     assertThat(suiteValidator.validateTestSuiteRun(testSuiteRun), equalTo(errorMessage));
   }
@@ -79,11 +81,11 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternIdNotInDb_expectError() throws StorageException {
     String patternCorrelationId = "company-project-suite-name-123456789";
-    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(
+        Collections.singleton(patternCorrelationId));
 
     String errorMessage = String.format(
-        "Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
-        patternCorrelationId, null);
+        "Incorrect patterns: '[%s]'. Not found in database.", patternCorrelationId);
     assertThat(suiteValidator.validateTestSuiteRun(testSuiteRun), equalTo(errorMessage));
     verify(metadataDAO).getSuite(any(), eq(patternCorrelationId));
   }
@@ -91,11 +93,10 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternSuiteNotInDb_expectError() throws StorageException {
     String patternSuite = "suite-name";
-    when(testSuiteRun.getPatternsSuite()).thenReturn(patternSuite);
+    when(testSuiteRun.getPatternsSuite()).thenReturn(Collections.singleton(patternSuite));
 
     String errorMessage = String.format(
-        "Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
-        null, patternSuite);
+        "Incorrect patterns: '[%s]'. Not found in database.", patternSuite);
     assertThat(suiteValidator.validateTestSuiteRun(testSuiteRun), equalTo(errorMessage));
     verify(metadataDAO).getLatestRun(any(), eq(patternSuite));
   }
@@ -119,7 +120,8 @@ public class SuiteValidatorTest {
       throws StorageException {
     String patternCorrelationId = "company-project-suite-name-123456789";
     Suite patternSuite = new Suite(patternCorrelationId, COMPANY, PROJECT, "suite-name", null);
-    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(
+        Collections.singleton(patternCorrelationId));
     when(metadataDAO.getSuite(any(), eq(patternCorrelationId))).thenReturn(patternSuite);
 
     assertNull(suiteValidator.validateTestSuiteRun(testSuiteRun));
@@ -143,5 +145,4 @@ public class SuiteValidatorTest {
     when(testRun.getCollectorSteps()).thenReturn(Collections.singletonList(screenCollectorStep));
     when(testRun.getComparatorSteps()).thenReturn(Collections.emptyMap());
   }
-
 }

--- a/test-executor/src/test/java/com/cognifide/aet/executor/SuiteValidatorTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/SuiteValidatorTest.java
@@ -68,7 +68,7 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternIdFromDifferentProject_expectError() {
     String patternCorrelationId = "company1-project1-suite-name-123456789";
-    when(testSuiteRun.getPatternCorrelationId()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
 
     String errorMessage = String.format(
         "Incorrect pattern: '%s'. Must belong to same company (%s) and project (%s).",
@@ -79,7 +79,7 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternIdNotInDb_expectError() throws StorageException {
     String patternCorrelationId = "company-project-suite-name-123456789";
-    when(testSuiteRun.getPatternCorrelationId()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
 
     String errorMessage = String.format(
         "Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
@@ -91,7 +91,7 @@ public class SuiteValidatorTest {
   @Test
   public void validateTestSuiteRun_whenPatternSuiteNotInDb_expectError() throws StorageException {
     String patternSuite = "suite-name";
-    when(testSuiteRun.getPatternSuite()).thenReturn(patternSuite);
+    when(testSuiteRun.getPatternsSuite()).thenReturn(patternSuite);
 
     String errorMessage = String.format(
         "Incorrect pattern: correlationId='%s', suiteName='%s'. Not found in database.",
@@ -119,7 +119,7 @@ public class SuiteValidatorTest {
       throws StorageException {
     String patternCorrelationId = "company-project-suite-name-123456789";
     Suite patternSuite = new Suite(patternCorrelationId, COMPANY, PROJECT, "suite-name", null);
-    when(testSuiteRun.getPatternCorrelationId()).thenReturn(patternCorrelationId);
+    when(testSuiteRun.getPatternsCorrelationIds()).thenReturn(patternCorrelationId);
     when(metadataDAO.getSuite(any(), eq(patternCorrelationId))).thenReturn(patternSuite);
 
     assertNull(suiteValidator.validateTestSuiteRun(testSuiteRun));


### PR DESCRIPTION
This is work in progress so everything may be subject to change, but I am uploading this after suggestion from @Skejven, for AET contributors to review and give feedback/suggestions.

Relates to #332 #424 

***General idea:***

The general idea behind these changes, is to allow user to provide multiple patternSuites/patternCorrelationIds when running suite, so the tests would be compared against not one but many patterns. This feature is actually based on already existing feature `Shared Patterns` but it expands it, allowing to provide more than one pattern references. 

Code from #424 will be eventually added to this functionality as well, which will basically provide yet another way in which user could pass references to shared patterns (by project checksum).

***Roadmap:***

Branch so far contains changes:
 - allow users to pass multiple patternSuite and patternCorrelationId params,
 - change java code structures to process collection of patterns through whole flow of running tests

To do:
 - introduce new structures in code to hold information about individual patterns (for example, so user can know what suite each individual pattern comes from, no longer a 1:1 relation),
 - adapt database to changes introduced in code,
 - implement frontend logic,
 - change frontend raport layout in a way it is able to present results with multiple patterns,
 - integrate with code from #424 


---
I hereby agree to the terms of the AET Contributor License Agreement.
