### PR TITLE
Changed logic for sidepanel report container's height

### DIFF
--- a/report/src/main/webapp/app/layout/sidepanel/sidepanel.view.html
+++ b/report/src/main/webapp/app/layout/sidepanel/sidepanel.view.html
@@ -125,7 +125,7 @@
     </div>
   </div>
 
-  <div class="aside-report-container">
+  <div class="aside-report-container" ng-class="sidepanel.thereAreChangesToSave() ? 'aside-report-container_short' : ''">
     <div ng-repeat="test in sidepanel.tests | orderBy:'name'"
          class="aside-report {{filteredUrls.length > 0 ? 'is-visible' : 'is-hidden'}}">
       <a ui-sref="test({'suite':$root.params.project, 'test':test.name})" ui-sref-active="is-active"

--- a/report/src/main/webapp/assets/sass/_sidebar.scss
+++ b/report/src/main/webapp/assets/sass/_sidebar.scss
@@ -75,7 +75,7 @@
       height: calc(100vh - #{$side_bar_header_height});
       overflow: auto;
 
-      &:not(:last-child) {
+      &.aside-report-container_short {
         height: calc(100vh - #{$side_bar_header_height} - #{$side_bar_manage_changes_wrapper_height});
       }
     }


### PR DESCRIPTION
## Description
New logic was provided for changing sidepanel report container's height when save and discard changes buttons appear. Now it changes based on class added on same function that determines if buttons are hidden or not.

## Motivation and Context
Height was changing based on if the container is the last child. However, with Winter Theme the container is never at the end.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
