### PR TITLE
Unescaping already escaped xml URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to AET will be documented in this file.
 - [PR-404](https://github.com/Cognifide/aet/pull/404) Added missing tooltip for conditional tests
 - [PR-408](https://github.com/Cognifide/aet/pull/408) Advanced Screen Comparision button layout fix
 - [PR-410](https://github.com/Cognifide/aet/pull/410) Notification that displays when exclude-elements are not found on page now shows what specific elements were not found([#372](https://github.com/Cognifide/aet/issues/372)) 
+- [PR-460](https://github.com/Cognifide/aet/pull/460) Unescaping already escaped xml URLs ([#441](https://github.com/Cognifide/aet/issues/441)) 
 
 ## Version 3.1.0
 

--- a/test-executor/src/main/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtils.java
+++ b/test-executor/src/main/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtils.java
@@ -49,7 +49,7 @@ public final class EscapeUtils {
 
         if (attr.startsWith("href=")) {
           attr = String.format("href=\"%s\"",
-              StringEscapeUtils.escapeXml11(attr.substring(6, attr.length() - 1)));
+              StringEscapeUtils.escapeXml11(StringEscapeUtils.unescapeXml(attr.substring(6, attr.length() - 1))));
         }
         attrMatcher.appendReplacement(attrsStringBuffer, attr + " ");
       }

--- a/test-executor/src/test/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtilsTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtilsTest.java
@@ -28,6 +28,14 @@ public class EscapeUtilsTest {
 
   @Test
   public void escapeUrls_expectEscapedResults() throws IOException {
+    String xmlString = readContentFromFile("/testSuite_unescapedUrls.xml");
+    String escapedXmlString = EscapeUtils.escapeUrls(xmlString);
+    String resultString = readContentFromFile("/testSuite_escapedUrls_result.xml");
+    assertThat(escapedXmlString, is(resultString));
+  }
+
+  @Test
+  public void escapeUrls_alreadyEscaped_expectUnchangedResults() throws IOException{
     String xmlString = readContentFromFile("/testSuite_escapedUrls.xml");
     String escapedXmlString = EscapeUtils.escapeUrls(xmlString);
     String resultString = readContentFromFile("/testSuite_escapedUrls_result.xml");

--- a/test-executor/src/test/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtilsTest.java
+++ b/test-executor/src/test/java/com/cognifide/aet/executor/xmlparser/xml/utils/EscapeUtilsTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class EscapeUtilsTest {
 
   @Test
-  public void escapeUrls_expectEscapedResults() throws IOException {
+  public void givenUnescapedUrls_whenEscape_expectEscapedResults() throws IOException {
     String xmlString = readContentFromFile("/testSuite_unescapedUrls.xml");
     String escapedXmlString = EscapeUtils.escapeUrls(xmlString);
     String resultString = readContentFromFile("/testSuite_escapedUrls_result.xml");
@@ -35,7 +35,7 @@ public class EscapeUtilsTest {
   }
 
   @Test
-  public void escapeUrls_alreadyEscaped_expectUnchangedResults() throws IOException{
+  public void givenEscapedUrls_whenEscape_expectUnchangedResults() throws IOException{
     String xmlString = readContentFromFile("/testSuite_escapedUrls.xml");
     String escapedXmlString = EscapeUtils.escapeUrls(xmlString);
     String resultString = readContentFromFile("/testSuite_escapedUrls_result.xml");

--- a/test-executor/src/test/resources/testSuite_escapedUrls.xml
+++ b/test-executor/src/test/resources/testSuite_escapedUrls.xml
@@ -31,9 +31,9 @@
 			<source comparator="w3c"/>
 		</compare>
 		<urls>
-			<url  name="value" href="http://www.google.pl&" 	name1="value1" name2="value2"/>
-			<url href="https://www.google.pl/search?q=googe&oq=googe&aqs=chrome..69i57j0l5.767j0j7&sourceid=chrome&es_sm=93&ie=UTF-8"/>
-			<url href="http://www.google.pl/search?g=<>'"/>
+			<url name="value" href="http://www.google.pl&amp;" name1="value1" name2="value2" />
+			<url href="https://www.google.pl/search?q=googe&amp;oq=googe&amp;aqs=chrome..69i57j0l5.767j0j7&amp;sourceid=chrome&amp;es_sm=93&amp;ie=UTF-8" />
+			<url href="http://www.google.pl/search?g=&lt;&gt;&apos;" />
 		</urls>
 	</test>
 </suite>

--- a/test-executor/src/test/resources/testSuite_unescapedUrls.xml
+++ b/test-executor/src/test/resources/testSuite_unescapedUrls.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    AET
+
+    Copyright (C) 2013 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<suite name="TS1" company="Cognifide" >
+	<test name="test2" useProxy="false">
+		<collect>
+			<open/>
+			<sleep duration="1500"/>
+			<screen/>
+			<source/>
+		</collect>
+		<compare>
+			<screen/>
+			<source comparator="w3c"/>
+		</compare>
+		<urls>
+			<url name="value" href="http://www.google.pl&" 	name1="value1" name2="value2"/>
+			<url href="https://www.google.pl/search?q=googe&oq=googe&aqs=chrome..69i57j0l5.767j0j7&sourceid=chrome&es_sm=93&ie=UTF-8"/>
+			<url href="http://www.google.pl/search?g=<>'"/>
+		</urls>
+	</test>
+</suite>


### PR DESCRIPTION
I made a change fixing unescaped URLs in report page. For details see #441.

## Description
Current implementation expects unescaped URLs in suite XML (e.g `(...)?a=b&c=d` ) which are then escaped before serializing XML to TestSuite. If you put correctly escaped XML in URL (e.g `(...)?a=b&amp;c=d`) then the query params are escaped to `(...)?a=b&amp;amp;c=d`, parsed back (while serializing) to `(...)a=b&amp;c=d` and this version is then displayed in report page.

This redundancy in escaping is what causes the issue. If the URLs are already escaped they shouldn't be tampered with. My fix uses the simpliest solution, i.e it tries to unescape before escaping, thus handling correctly both unescaped (unescape has no effect here) and escaped URLs. 

I also added a unit test for escaped URLs.
## Motivation and Context
Closes #441 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
