### PR TITLE
Fix SuiteRemoveCondition unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to AET will be documented in this file.
 - [PR-413](https://github.com/Cognifide/aet/pull/413) Added ability to show full page source when there has been no difference discovered ([#369](https://github.com/Cognifide/aet/issues/369))
 
 - [PR-463](https://github.com/Cognifide/aet/pull/463) Removed dependency to Joda time library
+- [PR-488](https://github.com/Cognifide/aet/pull/488) Fix SuiteRemoveCondition unit test
 
 ## Version 3.2.0
 

--- a/core/cleaner/src/test/java/com/cognifide/aet/cleaner/processors/filters/SuiteRemoveConditionTest.java
+++ b/core/cleaner/src/test/java/com/cognifide/aet/cleaner/processors/filters/SuiteRemoveConditionTest.java
@@ -50,10 +50,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertFalse(remove);
   }
 
@@ -80,10 +80,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertTrue(remove);
   }
 
@@ -106,10 +106,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertFalse(remove);
   }
 
@@ -134,10 +134,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertTrue(remove);
   }
 
@@ -153,10 +153,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertFalse(remove);
   }
 
@@ -172,10 +172,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertTrue(remove);
   }
 
@@ -191,10 +191,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertFalse(remove);
   }
 
@@ -206,10 +206,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertTrue(remove);
   }
 
@@ -222,10 +222,10 @@ public class SuiteRemoveConditionTest {
       Long removeOlderThan, Long keepNVersions, String evaluatedSuite, Integer createdDaysAgo) {
     final List<Suite> suites = SUITES_LIST_COERCER.toList(allSuitesVersions);
 
+    Suite suite = mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo);
     SuiteRemoveCondition condition = new SuiteRemoveCondition(suites,
         mockRemoveConditions(removeOlderThan, keepNVersions));
-    final boolean remove = condition
-        .evaluate(mockSuiteVersionAndCreatedDate(evaluatedSuite, createdDaysAgo));
+    final boolean remove = condition.evaluate(suite);
     assertFalse(remove);
   }
 


### PR DESCRIPTION
I fixed a SuiteRemoveConditionTest class which led to occasional tests failure.

## Description
I noticed that running SuiteRemoveConditionTest caused different results each time. Out of 100 runs, 87 ended successfully and 13 failed. Each fail was caused from assertion error in `evaluate_when8SuitesRemoveOlderThanButAlwaysKeepLatestVersion_expectTrue()` when testing the following suite list:  `A-1,A-2,B-3,B-4,C-5,C-6,D-7,E-8 ; 4 ; null ; C-5 ; 4`.
In this test we check if suite created 4 days ago is marked as "to be removed" if cleaner removes suites 4 days old and older.

The problem resulted from incorrect order of initalizations: first we create SuiteRemoveCondition with max acceptable timestamp (now minus 4 days) and then mocked Suite (with creation date: now minus 4 days). The offset between "now" value in these cases led to the Suite being considered younger than 4 days from the condition's perspective. The difference is so small that in some cases the test passes, but the bug is evident if you use a breakpoint between the two initializations (increasing the time difference - then it fails every time).

I changed the order in all methods to prevent future mistakes.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
