### PR TITLE
Bugfix/Claner removing too many artifacts after timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to AET will be documented in this file.
 - [PR-413](https://github.com/Cognifide/aet/pull/413) Added ability to show full page source when there has been no difference discovered ([#369](https://github.com/Cognifide/aet/issues/369))
 
 - [PR-463](https://github.com/Cognifide/aet/pull/463) Removed dependency to Joda time library
+- [PR-490](https://github.com/Cognifide/aet/pull/490) Bugfix/Claner removing to many artifacts
 
 ## Version 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to AET will be documented in this file.
 - [PR-413](https://github.com/Cognifide/aet/pull/413) Added ability to show full page source when there has been no difference discovered ([#369](https://github.com/Cognifide/aet/issues/369))
 
 - [PR-463](https://github.com/Cognifide/aet/pull/463) Removed dependency to Joda time library
+- [PR-488](https://github.com/Cognifide/aet/pull/488) Fix SuiteRemoveCondition unit test
 - [PR-490](https://github.com/Cognifide/aet/pull/490) Fix removing too many artifacts by cleaner job by terminating processing in case of timeout
 
 ## Version 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to AET will be documented in this file.
 - [PR-413](https://github.com/Cognifide/aet/pull/413) Added ability to show full page source when there has been no difference discovered ([#369](https://github.com/Cognifide/aet/issues/369))
 
 - [PR-463](https://github.com/Cognifide/aet/pull/463) Removed dependency to Joda time library
-- [PR-490](https://github.com/Cognifide/aet/pull/490) Bugfix/Claner removing to many artifacts
+- [PR-490](https://github.com/Cognifide/aet/pull/490) Fix removing too many artifacts by cleaner job by terminating processing in case of timeout
 
 ## Version 3.2.0
 

--- a/core/cleaner/src/main/java/com/cognifide/aet/cleaner/route/MetadataCleanerRouteBuilder.java
+++ b/core/cleaner/src/main/java/com/cognifide/aet/cleaner/route/MetadataCleanerRouteBuilder.java
@@ -89,6 +89,7 @@ public class MetadataCleanerRouteBuilder extends RouteBuilder {
         .aggregate(body().method("getDbKey"), new SuitesAggregationStrategy())
         .completionSize(header(SuiteAggregationCounter.NAME_KEY).method("getSuitesToAggregate"))
         .completionTimeout(60000L).forceCompletionOnStop()
+        .discardOnCompletionTimeout()
         .to(direct("removeArtifacts"));
 
     from(direct("removeArtifacts"))


### PR DESCRIPTION
Fixed cleaner bug resulting in removing too many artifacts from database after timeout.

## Description
Added discarding cleaner processing in case of aggregating task resulting in timeout. 

Aggregating task outputs a list of referenced artifacts. Cleaner then removes all artifacts not present in the list. In case of timeout occurring, incomplete list of artifacts is passed further and as a result too many artifacts are removed from db.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
