### PR TITLE
Fix race condition under non-native bash environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to AET will be documented in this file.
 **List of changes that are finished but not yet released in any final version.**
 
 - [PR-522](https://github.com/Cognifide/aet/pull/522) Improve performance of generating /configs/list. ([#519](https://github.com/Cognifide/aet/issues/519))
+- [PR-554](https://github.com/Cognifide/aet/pull/554) Fix race condition under non-native bash environments ([#551](https://github.com/Cognifide/aet/issues/551))
 
 
 ## Version 3.3.0

--- a/client/client-scripts/aet.sh
+++ b/client/client-scripts/aet.sh
@@ -169,8 +169,8 @@ while $process_status; do
     extract_code_and_body "$status_response"
 
     if [ $code -eq 200 ]; then
-        status=$(echo $body | jq -r ".status")
-        message=$(echo $body | jq -r ".message")
+        status=$(echo "$body" | jq -r ".status")
+        message=$(echo "$body" | jq -r ".message")
 
         case "$status" in
             "FINISHED")


### PR DESCRIPTION
## Description
Force treating `body` as string. Under non-native (e.g. cygwin, mingw) bash environments this may cause a race condition when checking suite status, resulting in a timeout and a 404 that gets passed to user.

## Motivation and Context
Fixes #551.

## Upgrade notes (if appropriate)
Manual upgrade of `aet.sh` will be required.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [x] I have reviewed (and updated if needed) the documentation regarding this change

---
I hereby agree to the terms of the AET Contributor License Agreement.
